### PR TITLE
ABD-35: Update Event Emitter to encrypt event messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,13 @@ repositories {
 
 dependencies {
     compile     'joda-time:joda-time:2.9.9',
-                'com.google.inject:guice:4.0'
+                'com.google.inject:guice:4.0',
+                'com.amazonaws:aws-java-sdk-sqs:1.11.277',
+                'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.8.10'
     testCompile 'junit:junit:4.12',
-                'org.assertj:assertj-core:3.9.0'
+                'org.assertj:assertj-core:3.9.0',
+                'org.mockito:mockito-core:1.9.5',
+                'cloud.localstack:localstack-utils:0.1.9'
 }
 
 task sourceJar(type: Jar) {

--- a/src/main/java/uk/gov/ida/eventemitter/Encrypter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/Encrypter.java
@@ -1,0 +1,6 @@
+package uk.gov.ida.eventemitter;
+
+public interface Encrypter {
+
+    String encrypt(final Event event) throws Exception;
+}

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitter.java
@@ -5,17 +5,35 @@ import javax.inject.Inject;
 public class EventEmitter {
 
     private final boolean sendToRecordingSystem;
+    private final Encrypter encrypter;
+    private final SqsClient sqsClient;
 
     @Inject
-    public EventEmitter(boolean sendToRecordingSystem) {
+    public EventEmitter(final boolean sendToRecordingSystem,
+                        final Encrypter encrypter,
+                        final SqsClient sqsClient) {
         this.sendToRecordingSystem = sendToRecordingSystem;
+        this.encrypter = encrypter;
+        this.sqsClient = sqsClient;
     }
 
-    public void record(Event event) {
+    public void record(final Event event) {
         if (sendToRecordingSystem) {
-            System.out.println(
-                String.format("Event ID: %s, Timestamp: %s, Event Type: %s",
-                    event.getEventId(), event.getTimestamp(), event.getEventType()));
+            String encryptedEvent = null;
+            try {
+                encryptedEvent = encrypter.encrypt(event);
+                System.out.println(String.format(
+                    "Event ID: %s, Timestamp: %s, Event Type: %s, Event String: %s",
+                    event.getEventId(),
+                    event.getTimestamp(),
+                    event.getEventType(),
+                    encryptedEvent
+                ));
+                sqsClient.sendToSqs(encryptedEvent);
+            } catch (Exception e) {
+                System.err.println(String.format("Failed to record an event %s. Error message: %s", event.getEventId(), e.getMessage()));
+                System.err.println(String.format("Event Message: %s", encryptedEvent));
+            }
         }
     }
 }

--- a/src/main/java/uk/gov/ida/eventemitter/LocalEncrypter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/LocalEncrypter.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.eventemitter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import org.apache.commons.codec.binary.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class LocalEncrypter implements Encrypter {
+
+    private final String key;
+    private final String initVector;
+    private final ObjectMapper mapper;
+
+    @Inject
+    public LocalEncrypter(final String key,
+                          final String initVector,
+                          final ObjectMapper mapper) {
+        this.key = key;
+        this.initVector = initVector;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String encrypt(final Event event) throws Exception {
+        final IvParameterSpec iv = new IvParameterSpec(initVector.getBytes("UTF-8"));
+        final SecretKeySpec skeySpec = new SecretKeySpec(key.getBytes("UTF-8"), "AES");
+        final Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+        cipher.init(Cipher.ENCRYPT_MODE, skeySpec, iv);
+        final byte[] encryptedEvent = cipher.doFinal(mapper.writeValueAsBytes(event));
+        return Base64.encodeBase64String(encryptedEvent);
+    }
+}

--- a/src/main/java/uk/gov/ida/eventemitter/SqsClient.java
+++ b/src/main/java/uk/gov/ida/eventemitter/SqsClient.java
@@ -1,0 +1,30 @@
+package uk.gov.ida.eventemitter;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.google.inject.Inject;
+
+import javax.inject.Named;
+
+public class SqsClient {
+
+    private final AmazonSQS sqs;
+    private final String eventQueueUrl;
+
+    @Inject
+    public SqsClient(final AmazonSQS sqs, @Named("EventQueueUrl") final String eventQueueUrl) {
+        this.sqs = sqs;
+        this.eventQueueUrl = eventQueueUrl;
+    }
+
+    public void sendToSqs(String event) {
+        try {
+            final SendMessageRequest sendMessageRequest = new SendMessageRequest(eventQueueUrl, event);
+            sqs.sendMessage(sendMessageRequest);
+            System.out.println("Sent a message to the queue successfully.");
+        } catch (AmazonClientException ace) {
+            System.err.println("Failed to send the message to the queue. Error Message: " + ace.getMessage());
+        }
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/Decrypter.java
+++ b/src/test/java/uk/gov/ida/eventemitter/Decrypter.java
@@ -1,0 +1,6 @@
+package uk.gov.ida.eventemitter;
+
+public interface Decrypter<T> {
+
+    T decrypt(final String encryptedEvent, final Class<T> klass) throws Exception;
+}

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -1,0 +1,118 @@
+package uk.gov.ida.eventemitter;
+
+import cloud.localstack.LocalstackTestRunner;
+import cloud.localstack.TestUtils;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.google.inject.name.Names;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+@RunWith(LocalstackTestRunner.class)
+public class EventEmitterIntegrationTest {
+
+    private static final String KEY = "aesEncryptionKey";
+    private static final String INIT_VECTOR = "encryptionIntVec";
+
+    private static Injector injector;
+    private static String queueUrl;
+    private static AmazonSQS clientSqs;
+
+    @BeforeClass
+    public static void setUp() {
+        injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() { }
+
+            @Provides
+            @Singleton
+            private AmazonSQS getAmazonSqs() {
+                return TestUtils.getClientSQS();
+            }
+
+            @Provides
+            @Singleton
+            @Named("EventQueueUrl")
+            public String getEventEmitter(AmazonSQS sqs) {
+                return sqs.createQueue(new CreateQueueRequest("queueName")).getQueueUrl();
+            }
+
+            @Provides
+            @Singleton
+            private SqsClient getSqsClient(AmazonSQS sqs, @Named("EventQueueUrl") String eventQueueUrl) {
+                return new SqsClient(sqs, eventQueueUrl);
+            }
+
+            @Provides
+            @Singleton
+            private Encrypter getEncrypter(ObjectMapper objectMapper) {
+                return new LocalEncrypter(KEY, INIT_VECTOR, objectMapper);
+            }
+
+            @Provides
+            @Singleton
+            private ObjectMapper getObjectMapper() {
+                ObjectMapper mapper = new ObjectMapper();
+                mapper.registerModule(new JodaModule());
+                return mapper;
+            }
+
+            @Provides
+            @Singleton
+            private EventEmitter getEventEmitter(Encrypter encrypter, SqsClient client) {
+                return new EventEmitter(true, encrypter, client);
+            }
+        });
+        clientSqs = injector.getInstance(AmazonSQS.class);
+        queueUrl = injector.getInstance(Key.get(String.class, Names.named("EventQueueUrl")));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        clientSqs.deleteQueue(queueUrl);
+    }
+
+    @Test
+    public void shouldEncryptMessageAndSendToSQS() throws Exception {
+        final Event expectedEvent = new TestEvent(UUID.randomUUID(), DateTime.now(DateTimeZone.UTC), "eventType");
+
+        EventEmitter eventEmitter = injector.getInstance(EventEmitter.class);
+        eventEmitter.record(expectedEvent);
+
+        final Message message = getAnEncryptedMessageFromSqs();
+        clientSqs.deleteMessage(queueUrl, message.getReceiptHandle());
+        final LocalDecrypter<TestEvent> decrypter = new LocalDecrypter(KEY, INIT_VECTOR, injector.getInstance(ObjectMapper.class));
+        final Event actualEvent = decrypter.decrypt(message.getBody(), TestEvent.class);
+
+        assertThat(actualEvent).isEqualTo(expectedEvent);
+    }
+
+    private Message getAnEncryptedMessageFromSqs() {
+        final ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
+        final List<Message> messages = clientSqs.receiveMessage(receiveMessageRequest).getMessages();
+
+        assertThat(messages).hasSize(1);
+
+        return messages.get(0);
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterTest.java
@@ -1,68 +1,112 @@
 package uk.gov.ida.eventemitter;
 
 import org.joda.time.DateTime;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class EventEmitterTest {
 
-    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private static final String ENCRYPTED_EVENT = "encrypted event";
+    private static final UUID ID = UUID.randomUUID();
+    private static final String TIMESTAMP = "2018-02-06T14:37:55.467Z";
+    private static final String EVENT_TYPE = "Error Event";
 
     private EventEmitter eventEmitter;
     private EventEmitter eventEmitterWithoutRecordingSystem;
+    private TestEvent event;
+
+    @Mock
+    private Encrypter encrypter;
+
+    @Mock
+    private SqsClient sqsClient;
 
     @Before
-    public void setUp() {
-        System.setOut(new PrintStream(outContent));
+    public void setUp() throws Exception {
+        when(encrypter.encrypt(any(Event.class))).thenReturn(ENCRYPTED_EVENT);
 
-        eventEmitter = new EventEmitter(true);
-        eventEmitterWithoutRecordingSystem = new EventEmitter(false);
-    }
+        eventEmitter = new EventEmitter(true, encrypter, sqsClient);
+        eventEmitterWithoutRecordingSystem = new EventEmitter(false, encrypter, sqsClient);
 
-    @After
-    public void tearDown() {
-        System.setOut(System.out);
+        event = new TestEvent(ID, DateTime.parse(TIMESTAMP), EVENT_TYPE);
     }
 
     @Test
-    public void recordMethodShouldWriteEventDetailsToSystemOut() {
-        final UUID id = UUID.randomUUID();
-        final String timestamp = "2018-02-06T14:37:55.467Z";
-        final String eventType = "Error Event";
-        final TestEvent event = new TestEvent(id, DateTime.parse(timestamp), eventType);
+    public void shouldLogEventDetailsWhenEventEmitterIsConfiguredToSendToSqs() throws IOException {
+        try (ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+             PrintStream printStream = new PrintStream(outContent)) {
+            System.setOut(printStream);
+            eventEmitter.record(event);
+            System.setOut(System.out);
 
-        eventEmitter.record(event);
-
-        assertThat(outContent.toString())
-            .isEqualTo(String.format("Event ID: %s, Timestamp: %s, Event Type: %s\n", id, timestamp, eventType));
+            assertThat(outContent.toString()).containsOnlyOnce(String.format(
+                "Event ID: %s, Timestamp: %s, Event Type: %s, Event String: %s\n",
+                ID,
+                TIMESTAMP,
+                EVENT_TYPE,
+                ENCRYPTED_EVENT
+            ));
+        }
     }
 
     @Test
-    public void recordMethodShouldNotWriteEventDetailsToSystemOut() {
-        final UUID id = UUID.randomUUID();
-        final String timestamp = "2018-02-06T14:37:55.467Z";
-        final String eventType = "Error Event";
-        final TestEvent event = new TestEvent(id, DateTime.parse(timestamp), eventType);
+    public void shouldNotLogEventDetailsWhenEventEmitterIsConfiguredNotToSendToSqs() throws IOException {
+        try (ByteArrayOutputStream outContent = new ByteArrayOutputStream(); PrintStream printStream = new PrintStream(outContent)) {
+            System.setOut(printStream);
+            eventEmitterWithoutRecordingSystem.record(event);
+            System.setOut(System.out);
 
-        eventEmitterWithoutRecordingSystem.record(event);
-
-        assertThat(outContent.toString()).isEmpty();
+            assertThat(outContent.toString()).isEmpty();
+        }
     }
 
     @Test
-    public void shouldNotThrowErrorsIfInputsAreNull() {
-        final TestEvent event = new TestEvent(null, null, null);
+    public void shouldNotThrowErrorsIfInputsAreNull() throws IOException {
+        final TestEvent emptyEvent = new TestEvent(null, null, null);
 
-        eventEmitter.record(event);
+        try (ByteArrayOutputStream outContent = new ByteArrayOutputStream(); PrintStream printStream = new PrintStream(outContent)) {
+            System.setOut(printStream);
+            eventEmitter.record(emptyEvent);
+            System.setOut(System.out);
 
-        assertThat(outContent.toString())
-            .isEqualTo("Event ID: null, Timestamp: null, Event Type: null\n");
+            assertThat(outContent.toString()).containsOnlyOnce(String.format(
+                "Event ID: null, Timestamp: null, Event Type: null, Event String: %s\n",
+                ENCRYPTED_EVENT
+            ));
+        }
+    }
+
+    @Test
+    public void shouldLogErrorToSystemErrorWhenEventEmitterIsUnableToSendToSqs() throws IOException {
+        final String errorMessage = "Failed to send to SQS";
+        doThrow(new RuntimeException(errorMessage)).when(sqsClient).sendToSqs(anyString());
+
+        try (ByteArrayOutputStream errorContent = new ByteArrayOutputStream(); PrintStream printStream = new PrintStream(errorContent)) {
+            System.setErr(printStream);
+            eventEmitter.record(event);
+            System.setErr(System.err);
+
+            assertThat(errorContent.toString()).containsOnlyOnce(String.format(
+                "Failed to record an event %s. Error message: %s\nEvent Message: %s",
+                ID,
+                errorMessage,
+                ENCRYPTED_EVENT
+            ));
+        }
     }
 }

--- a/src/test/java/uk/gov/ida/eventemitter/LocalDecrypter.java
+++ b/src/test/java/uk/gov/ida/eventemitter/LocalDecrypter.java
@@ -1,0 +1,34 @@
+package uk.gov.ida.eventemitter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import org.apache.commons.codec.binary.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class LocalDecrypter<T> implements Decrypter<T>{
+
+    private final String key;
+    private final String initVector;
+    private final ObjectMapper mapper;
+
+    @Inject
+    public LocalDecrypter(final String key,
+                          final String initVector,
+                          final ObjectMapper mapper) {
+        this.key = key;
+        this.initVector = initVector;
+        this.mapper = mapper;
+    }
+
+    public T decrypt(final String encryptedEvent, final Class<T> klass) throws Exception {
+        final IvParameterSpec iv = new IvParameterSpec(initVector.getBytes("UTF-8"));
+        final SecretKeySpec skeySpec = new SecretKeySpec(key.getBytes("UTF-8"), "AES");
+        final Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+        cipher.init(Cipher.DECRYPT_MODE, skeySpec, iv);
+        final byte[] original = cipher.doFinal(Base64.decodeBase64(encryptedEvent));
+        return (T) mapper.readValue(original, klass);
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/LocalEncryptionTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/LocalEncryptionTest.java
@@ -1,0 +1,77 @@
+package uk.gov.ida.eventemitter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class LocalEncryptionTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static final String KEY = "aesEncryptionKey";
+    private static final String INIT_VEC = "encryptionIntVec";
+    private Encrypter encrypter;
+    private Decrypter<TestEvent> decrypter;
+    private static final UUID EVENT_ID = UUID.randomUUID();
+    private static final Event EVENT = new TestEvent(EVENT_ID, DateTime.now(DateTimeZone.UTC), "eventType");
+    private ObjectMapper mapper = new ObjectMapper();
+
+    @Before
+    public void setUp() {
+        mapper.registerModule(new JodaModule());
+        encrypter = new LocalEncrypter(KEY, INIT_VEC, mapper);
+        decrypter = new LocalDecrypter(KEY, INIT_VEC, mapper);
+    }
+
+    @Test
+    public void shouldEncrypt() throws Exception {
+        final String encryptedEvent = encrypter.encrypt(EVENT);
+        final TestEvent actualEvent = decrypter.decrypt(encryptedEvent, TestEvent.class);
+
+        assertThat(actualEvent).isEqualToComparingFieldByFieldRecursively(EVENT);
+    }
+
+    @Test
+    public void ShouldLogErrorAfterFailingToEncrypt() throws Exception {
+        expectedException.expect(InvalidKeyException.class);
+
+        final Encrypter brokenEncrypter = new LocalEncrypter("badKey", INIT_VEC, mapper);
+
+        try (ByteArrayOutputStream errContent = new ByteArrayOutputStream(); PrintStream printStream = new PrintStream(errContent )) {
+            System.setErr(printStream);
+            final String encryptedEvent = brokenEncrypter.encrypt(EVENT);
+            System.setErr(System.err);
+        }
+    }
+
+    @Test
+    public void ShouldLogErrorAfterFailingToDecrypt() throws Exception {
+        expectedException.expect(InvalidAlgorithmParameterException.class);
+
+        final Decrypter<TestEvent> brokenDecrypter = new LocalDecrypter(KEY, "badInitVector", mapper);
+
+        try (ByteArrayOutputStream errContent = new ByteArrayOutputStream(); PrintStream printStream = new PrintStream(errContent )) {
+            System.setErr(printStream);
+            final String encryptedEvent = encrypter.encrypt(EVENT);
+            final Event actualEvent = brokenDecrypter.decrypt(encryptedEvent, TestEvent.class);
+            System.setErr(System.err);
+
+            assertThat(errContent.toString()).isEqualTo(String.format("Failed to decrypt an encrypted event. Error message: Wrong IV length: must be 16 bytes long\n", EVENT_ID));
+            assertThat(actualEvent).isNull();
+        }
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/SqsClientTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/SqsClientTest.java
@@ -1,0 +1,61 @@
+package uk.gov.ida.eventemitter;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SqsClientTest {
+
+    private static final String QUEUE_URL = "queueUrl";
+    private static final String EVENT = "event";
+    private static final SendMessageRequest SEND_MESSAGE_REQUEST = new SendMessageRequest(QUEUE_URL, EVENT);
+
+    @Mock
+    private AmazonSQS sqs;
+
+    private SqsClient sqsClient;
+
+    @Before
+    public void setUp() {
+        sqsClient = new SqsClient(sqs, QUEUE_URL);
+    }
+
+    @Test
+    public void shouldSendEventToSqs() {
+        final SendMessageResult result = new SendMessageResult();
+        when(sqs.sendMessage(SEND_MESSAGE_REQUEST)).thenReturn(result);
+
+        sqsClient.sendToSqs(EVENT);
+
+        verify(sqs).sendMessage(SEND_MESSAGE_REQUEST);
+    }
+
+    @Test
+    public void shouldLogErrorAfterFailingToSendAMessageToSqs() throws IOException {
+        doThrow(new AmazonClientException("SQS is down")).when(sqs).sendMessage(SEND_MESSAGE_REQUEST);
+
+        try (ByteArrayOutputStream errorContent = new ByteArrayOutputStream(); PrintStream printStream = new PrintStream(errorContent)) {
+            System.setErr(printStream);
+            sqsClient.sendToSqs(EVENT);
+            System.setErr(System.err);
+
+            assertThat(errorContent.toString()).contains("Failed to send the message to the queue. Error Message: SQS is down");
+        }
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/TestEvent.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestEvent.java
@@ -1,14 +1,23 @@
 package uk.gov.ida.eventemitter;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
 import java.util.UUID;
 
-public class TestEvent implements Event {
+public final class TestEvent implements Event {
 
-    private final UUID eventId;
-    private final DateTime timestamp;
-    private final String eventType;
+    @JsonProperty
+    private UUID eventId;
+
+    @JsonProperty
+    private DateTime timestamp;
+
+    @JsonProperty
+    private String eventType;
+
+    private TestEvent() {}
 
     public TestEvent(final UUID eventId, final DateTime timestamp, final String eventType) {
         this.eventId = eventId;
@@ -29,5 +38,37 @@ public class TestEvent implements Event {
     @Override
     public String getEventType() {
         return eventType;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("TestEvent{");
+        sb.append("eventId=").append(eventId);
+        sb.append(", timestamp=").append(timestamp);
+        sb.append(", eventType='").append(eventType).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TestEvent testEvent = (TestEvent) o;
+
+        return Objects.equals(eventId, testEvent.eventId) &&
+            Objects.equals(timestamp, testEvent.timestamp) &&
+            Objects.equals(eventType, testEvent.eventType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId, timestamp, eventType);
     }
 }


### PR DESCRIPTION
Update Event Emitter to send encrypted event messages to SQS.
Add Event Emitter Configuration to enable client applications to use it
for configuring Event Emitter.

Authors: @adityapahuja @michaelwalker