### PR TITLE
ABD-35: Update Event Emitter to support encryption and SQS services

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,16 @@ repositories {
 
 dependencies {
     compile     'joda-time:joda-time:2.9.9',
-                'com.google.inject:guice:4.0'
+                'com.google.inject:guice:4.0',
+                'com.amazonaws:aws-java-sdk-sqs:1.11.277',
+                'com.amazonaws:aws-java-sdk-kms:1.11.277',
+                'com.amazonaws:aws-encryption-sdk-java:1.3.1',
+                'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.8.10'
+
     testCompile 'junit:junit:4.12',
-                'org.assertj:assertj-core:3.9.0'
+                'org.assertj:assertj-core:3.9.0',
+                'org.mockito:mockito-core:1.9.5',
+                'cloud.localstack:localstack-utils:0.1.9'
 }
 
 task sourceJar(type: Jar) {

--- a/src/main/java/uk/gov/ida/eventemitter/AmazonEncrypter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/AmazonEncrypter.java
@@ -1,0 +1,30 @@
+package uk.gov.ida.eventemitter;
+
+import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class AmazonEncrypter implements Encrypter {
+
+    private final AwsCrypto awsCrypto;
+    private final KmsMasterKeyProvider provider;
+    private final ObjectMapper mapper;
+
+    public AmazonEncrypter(final AwsCrypto awsCrypto,
+                           final KmsMasterKeyProvider provider,
+                           final ObjectMapper mapper) {
+        this.awsCrypto = awsCrypto;
+        this.mapper = mapper;
+        this.provider = provider;
+    }
+
+    @Override
+    public String encrypt(final Event event) throws JsonProcessingException {
+        final Map<String, String> context = Collections.EMPTY_MAP;
+        return awsCrypto.encryptString(provider, mapper.writeValueAsString(event), context).getResult();
+    }
+}

--- a/src/main/java/uk/gov/ida/eventemitter/AmazonSqsClient.java
+++ b/src/main/java/uk/gov/ida/eventemitter/AmazonSqsClient.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.eventemitter;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.google.inject.Inject;
+
+import javax.inject.Named;
+
+public class AmazonSqsClient implements SqsClient {
+
+    private final AmazonSQS sqs;
+    private final String queueUrl;
+
+    @Inject
+    public AmazonSqsClient(final AmazonSQS sqs,
+                           @Named("QueueUrl") final String queueUrl) {
+        this.sqs = sqs;
+        this.queueUrl = queueUrl;
+    }
+
+    @Override
+    public void send(final Event event, final String encryptedEvent) throws AmazonClientException {
+        final SendMessageRequest sendMessageRequest = new SendMessageRequest(queueUrl, encryptedEvent);
+        sqs.sendMessage(sendMessageRequest);
+        System.out.println(String.format("Sent a message [Event Id: %s] to the queue successfully.", event.getEventId()));
+    }
+}

--- a/src/main/java/uk/gov/ida/eventemitter/Configuration.java
+++ b/src/main/java/uk/gov/ida/eventemitter/Configuration.java
@@ -1,0 +1,6 @@
+package uk.gov.ida.eventemitter;
+
+public interface Configuration {
+
+    String getQueueName();
+}

--- a/src/main/java/uk/gov/ida/eventemitter/Encrypter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/Encrypter.java
@@ -1,0 +1,8 @@
+package uk.gov.ida.eventemitter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public interface Encrypter {
+
+    String encrypt(final Event event) throws JsonProcessingException;
+}

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitter.java
@@ -4,18 +4,28 @@ import javax.inject.Inject;
 
 public class EventEmitter {
 
-    private final boolean sendToRecordingSystem;
+    private final Encrypter encrypter;
+    private final SqsClient sqsClient;
 
     @Inject
-    public EventEmitter(boolean sendToRecordingSystem) {
-        this.sendToRecordingSystem = sendToRecordingSystem;
+    public EventEmitter(final Encrypter encrypter,
+                        final SqsClient sqsClient) {
+        this.encrypter = encrypter;
+        this.sqsClient = sqsClient;
     }
 
-    public void record(Event event) {
-        if (sendToRecordingSystem) {
-            System.out.println(
-                String.format("Event ID: %s, Timestamp: %s, Event Type: %s",
-                    event.getEventId(), event.getTimestamp(), event.getEventType()));
+    public void record(final Event event) {
+        if (event != null) {
+            String encryptedEvent = null;
+            try {
+                encryptedEvent = encrypter.encrypt(event);
+                sqsClient.send(event, encryptedEvent);
+            } catch (Exception e) {
+                System.err.println(String.format("Failed to send a message [Event Id: %s] to the queue. Error Message: %s", event.getEventId(), e.getMessage()));
+                System.err.println(String.format("Event Message: %s", encryptedEvent));
+            }
+        } else {
+            System.err.println("Unable to send a message due to event containing null value.");
         }
     }
 }

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -1,0 +1,49 @@
+package uk.gov.ida.eventemitter;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+import javax.inject.Named;
+import java.util.Optional;
+
+public class EventEmitterModule extends AbstractModule {
+
+    private Configuration configuration;
+
+    public EventEmitterModule(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    protected void configure() {}
+
+    @Provides
+    private Optional<AmazonSQS> getAmazonSqs() {
+        if (this.configuration.getQueueName() != null) {
+            return Optional.ofNullable(AmazonSQSClientBuilder.defaultClient());
+        }
+        return Optional.empty();
+    }
+
+    @Provides
+    @Named("QueueUrl")
+    private Optional<String> getQueueUrl(final Optional<AmazonSQS> amazonSqs) {
+        return amazonSqs.map(sqs -> sqs.getQueueUrl(configuration.getQueueName()).getQueueUrl());
+    }
+
+    @Provides
+    private SqsClient getAmazonSqsClient(final Optional<AmazonSQS> amazonSqs,
+                                         final @Named("QueueUrl") Optional<String> queueUrl) {
+        if (amazonSqs.isPresent() && queueUrl.isPresent()){
+            return new AmazonSqsClient(amazonSqs.get(), queueUrl.get());
+        }
+        return new StubSqsClient();
+    }
+
+    @Provides
+    private EventEmitter getEventEmitter(final SqsClient sqsClient) {
+        return new EventEmitter(new StubEncrypter(), sqsClient);
+    }
+}

--- a/src/main/java/uk/gov/ida/eventemitter/SqsClient.java
+++ b/src/main/java/uk/gov/ida/eventemitter/SqsClient.java
@@ -1,0 +1,6 @@
+package uk.gov.ida.eventemitter;
+
+public interface SqsClient {
+
+    void send(final Event event, final String encryptedEvent);
+}

--- a/src/main/java/uk/gov/ida/eventemitter/StubEncrypter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/StubEncrypter.java
@@ -1,0 +1,9 @@
+package uk.gov.ida.eventemitter;
+
+public class StubEncrypter implements Encrypter {
+
+    @Override
+    public String encrypt(final Event event)  {
+        return String.format("Encrypted Event Id %s", event.getEventId().toString());
+    }
+}

--- a/src/main/java/uk/gov/ida/eventemitter/StubSqsClient.java
+++ b/src/main/java/uk/gov/ida/eventemitter/StubSqsClient.java
@@ -1,0 +1,15 @@
+package uk.gov.ida.eventemitter;
+
+public class StubSqsClient implements SqsClient {
+
+    @Override
+    public void send(final Event event, final String encryptedEvent) {
+        System.out.println(String.format(
+            "Event ID: %s, Timestamp: %s, Event Type: %s, Event String: %s",
+            event.getEventId(),
+            event.getTimestamp(),
+            event.getEventType(),
+            encryptedEvent
+        ));
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/AmazonEncrypterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/AmazonEncrypterTest.java
@@ -1,0 +1,57 @@
+package uk.gov.ida.eventemitter;
+
+import com.amazonaws.encryptionsdk.AwsCrypto;
+import com.amazonaws.encryptionsdk.CryptoResult;
+import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AmazonEncrypterTest {
+
+    private static final UUID ID = UUID.randomUUID();
+    private static final DateTime TIMESTAMP = DateTime.now(DateTimeZone.UTC);
+    private static final String EVENT_TYPE = "Error Event";
+    private static final String ENCRYPTED_EVENT = "encryptedEvent";
+    private static final String JSON_STRING = "JSONString";
+
+    @Mock
+    private AwsCrypto awsCrypto;
+
+    @Mock
+    private KmsMasterKeyProvider provider;
+
+    @Mock
+    private ObjectMapper mapper;
+
+    @Mock
+    private CryptoResult cryptoResult;
+
+    @Test
+    public void shouldEncryptEvent() throws JsonProcessingException {
+        final AmazonEncrypter encrypter = new AmazonEncrypter(awsCrypto, provider, mapper);
+        final TestEvent event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
+        final Map<String, String> context = Collections.EMPTY_MAP;
+
+        when(mapper.writeValueAsString(event)).thenReturn(JSON_STRING);
+        when(awsCrypto.encryptString(provider, JSON_STRING, context)).thenReturn(cryptoResult);
+        when(cryptoResult.getResult()).thenReturn(ENCRYPTED_EVENT);
+
+        final String actualValue = encrypter.encrypt(event);
+
+        assertThat(actualValue).isEqualTo(ENCRYPTED_EVENT);
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/AmazonSqsClientTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/AmazonSqsClientTest.java
@@ -1,0 +1,54 @@
+package uk.gov.ida.eventemitter;
+
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.GetQueueUrlResult;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import com.amazonaws.services.sqs.model.SendMessageResult;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.UUID;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AmazonSqsClientTest {
+
+    private static final UUID ID = UUID.randomUUID();
+    private static final DateTime TIMESTAMP = DateTime.now(DateTimeZone.UTC);
+    private static final String EVENT_TYPE = "Error Event";
+    private static final String ENCRYPTED_EVENT = "encryptedEvent";
+    private static final String QUEUE_URL = "queueUrl";
+    private static final SendMessageRequest SEND_MESSAGE_REQUEST = new SendMessageRequest(QUEUE_URL, ENCRYPTED_EVENT);
+
+    @Mock
+    private AmazonSQS sqs;
+
+    @Mock
+    private GetQueueUrlResult queueUrlResult;
+
+    private AmazonSqsClient sqsClient;
+    private Event event;
+
+    @Before
+    public void setUp() {
+        sqsClient = new AmazonSqsClient(sqs, QUEUE_URL);
+    }
+
+    @Test
+    public void shouldSendEventToSqs() {
+        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
+        final SendMessageResult result = new SendMessageResult();
+        when(sqs.sendMessage(SEND_MESSAGE_REQUEST)).thenReturn(result);
+
+        sqsClient.send(event, ENCRYPTED_EVENT);
+
+        verify(sqs).sendMessage(SEND_MESSAGE_REQUEST);
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -1,17 +1,17 @@
 package uk.gov.ida.eventemitter;
 
 import cloud.localstack.LocalstackTestRunner;
-import cloud.localstack.TestUtils;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.CreateQueueRequest;
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
-import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
-import com.google.inject.Provides;
+import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
+import com.google.inject.util.Modules;
+import com.google.inject.util.Types;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.AfterClass;
@@ -19,9 +19,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -30,52 +29,25 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 public class EventEmitterIntegrationTest {
 
     private static final String QUEUE_NAME = "queueName";
+    private static final TestConfiguration CONFIGURATION = new TestConfiguration(QUEUE_NAME);
     private static Injector injector;
-    private static String queueUrl;
-    private static AmazonSQS clientSqs;
+    private static Optional<String> queueUrl;
+    private static Optional<AmazonSQS> clientSqs;
 
     @BeforeClass
     public static void setUp() {
-        injector = Guice.createInjector(new AbstractModule() {
-            @Override
-            protected void configure() {
-                bind(Encrypter.class).to(StubEncrypter.class).asEagerSingleton();
-            }
-
-            @Provides
-            @Singleton
-            private AmazonSQS getAmazonSqs() {
-                return TestUtils.getClientSQS();
-            }
-
-            @Provides
-            @Singleton
-            @Named("QueueUrl")
-            private String getQueueUrl() {
-                return clientSqs.getQueueUrl(QUEUE_NAME).getQueueUrl();
-            }
-
-            @Provides
-            @Singleton
-            private SqsClient getSqsClient(final AmazonSQS sqs,
-                                           @Named("QueueUrl") final String queueUrl) {
-                return new AmazonSqsClient(sqs, queueUrl);
-            }
-
-            @Provides
-            @Singleton
-            private EventEmitter getEventEmitter(Encrypter encrypter, SqsClient client) {
-                return new EventEmitter(encrypter, client);
-            }
-        });
-        clientSqs = injector.getInstance(AmazonSQS.class);
-        clientSqs.createQueue(new CreateQueueRequest(QUEUE_NAME));
-        queueUrl = injector.getInstance(Key.get(String.class, Names.named("QueueUrl")));
+        injector = Guice.createInjector(Modules.override(new EventEmitterModule(CONFIGURATION))
+            .with(new TestEventEmitterModule(CONFIGURATION)));
+        clientSqs = (Optional<AmazonSQS>) injector.getInstance(
+            Key.get(TypeLiteral.get(Types.newParameterizedType(Optional.class, AmazonSQS.class))));
+        clientSqs.get().createQueue(new CreateQueueRequest(QUEUE_NAME));
+        queueUrl = (Optional<String>) injector.getInstance(
+            Key.get(TypeLiteral.get(Types.newParameterizedType(Optional.class, String.class)), Names.named("QueueUrl")));
     }
 
     @AfterClass
     public static void tearDown() {
-        clientSqs.deleteQueue(queueUrl);
+        clientSqs.get().deleteQueue(queueUrl.get());
     }
 
     @Test
@@ -86,14 +58,14 @@ public class EventEmitterIntegrationTest {
         eventEmitter.record(event);
 
         final Message message = getAnEncryptedMessageFromSqs();
-        clientSqs.deleteMessage(queueUrl, message.getReceiptHandle());
+        clientSqs.get().deleteMessage(queueUrl.get(), message.getReceiptHandle());
 
         assertThat(message.getBody()).isEqualTo(String.format("Encrypted Event Id %s", event.getEventId().toString()));
     }
 
     private Message getAnEncryptedMessageFromSqs() {
-        final ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
-        final List<Message> messages = clientSqs.receiveMessage(receiveMessageRequest).getMessages();
+        final ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl.get());
+        final List<Message> messages = clientSqs.get().receiveMessage(receiveMessageRequest).getMessages();
 
         assertThat(messages.size()).isEqualTo(1);
         return messages.get(0);

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -1,0 +1,101 @@
+package uk.gov.ida.eventemitter;
+
+import cloud.localstack.LocalstackTestRunner;
+import cloud.localstack.TestUtils;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Provides;
+import com.google.inject.name.Names;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.inject.Named;
+import javax.inject.Singleton;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(LocalstackTestRunner.class)
+public class EventEmitterIntegrationTest {
+
+    private static final String QUEUE_NAME = "queueName";
+    private static Injector injector;
+    private static String queueUrl;
+    private static AmazonSQS clientSqs;
+
+    @BeforeClass
+    public static void setUp() {
+        injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {
+                bind(Encrypter.class).to(StubEncrypter.class).asEagerSingleton();
+            }
+
+            @Provides
+            @Singleton
+            private AmazonSQS getAmazonSqs() {
+                return TestUtils.getClientSQS();
+            }
+
+            @Provides
+            @Singleton
+            @Named("QueueUrl")
+            private String getQueueUrl() {
+                return clientSqs.getQueueUrl(QUEUE_NAME).getQueueUrl();
+            }
+
+            @Provides
+            @Singleton
+            private SqsClient getSqsClient(final AmazonSQS sqs,
+                                           @Named("QueueUrl") final String queueUrl) {
+                return new AmazonSqsClient(sqs, queueUrl);
+            }
+
+            @Provides
+            @Singleton
+            private EventEmitter getEventEmitter(Encrypter encrypter, SqsClient client) {
+                return new EventEmitter(encrypter, client);
+            }
+        });
+        clientSqs = injector.getInstance(AmazonSQS.class);
+        clientSqs.createQueue(new CreateQueueRequest(QUEUE_NAME));
+        queueUrl = injector.getInstance(Key.get(String.class, Names.named("QueueUrl")));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        clientSqs.deleteQueue(queueUrl);
+    }
+
+    @Test
+    public void shouldEncryptMessageAndSendToSQS() {
+        final EventEmitter eventEmitter = injector.getInstance(EventEmitter.class);
+        final Event event = new TestEvent(UUID.randomUUID(), DateTime.now(DateTimeZone.UTC), "eventType");
+
+        eventEmitter.record(event);
+
+        final Message message = getAnEncryptedMessageFromSqs();
+        clientSqs.deleteMessage(queueUrl, message.getReceiptHandle());
+
+        assertThat(message.getBody()).isEqualTo(String.format("Encrypted Event Id %s", event.getEventId().toString()));
+    }
+
+    private Message getAnEncryptedMessageFromSqs() {
+        final ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
+        final List<Message> messages = clientSqs.receiveMessage(receiveMessageRequest).getMessages();
+
+        assertThat(messages.size()).isEqualTo(1);
+        return messages.get(0);
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterTest.java
@@ -1,68 +1,83 @@
 package uk.gov.ida.eventemitter;
 
 import org.joda.time.DateTime;
-import org.junit.After;
+import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class EventEmitterTest {
 
-    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private static final UUID ID = UUID.randomUUID();
+    private static final DateTime TIMESTAMP = DateTime.now(DateTimeZone.UTC);
+    private static final String EVENT_TYPE = "Error Event";
+    private static final String ENCRYPTED_EVENT = "encrypted event";
 
     private EventEmitter eventEmitter;
-    private EventEmitter eventEmitterWithoutRecordingSystem;
+    private TestEvent event;
+
+    @Mock
+    private Encrypter encrypter;
+
+    @Mock
+    private SqsClient sqsClient;
 
     @Before
-    public void setUp() {
-        System.setOut(new PrintStream(outContent));
+    public void setUp() throws Exception {
+        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
+        when(encrypter.encrypt(event)).thenReturn(ENCRYPTED_EVENT);
 
-        eventEmitter = new EventEmitter(true);
-        eventEmitterWithoutRecordingSystem = new EventEmitter(false);
-    }
-
-    @After
-    public void tearDown() {
-        System.setOut(System.out);
+        eventEmitter = new EventEmitter(encrypter, sqsClient);
     }
 
     @Test
-    public void recordMethodShouldWriteEventDetailsToSystemOut() {
-        final UUID id = UUID.randomUUID();
-        final String timestamp = "2018-02-06T14:37:55.467Z";
-        final String eventType = "Error Event";
-        final TestEvent event = new TestEvent(id, DateTime.parse(timestamp), eventType);
-
+    public void shouldEncryptAndSendEncryptedEventToSqs() throws Exception {
         eventEmitter.record(event);
 
-        assertThat(outContent.toString())
-            .isEqualTo(String.format("Event ID: %s, Timestamp: %s, Event Type: %s\n", id, timestamp, eventType));
+         verify(encrypter).encrypt(event);
+         verify(sqsClient).send(event, ENCRYPTED_EVENT);
     }
 
     @Test
-    public void recordMethodShouldNotWriteEventDetailsToSystemOut() {
-        final UUID id = UUID.randomUUID();
-        final String timestamp = "2018-02-06T14:37:55.467Z";
-        final String eventType = "Error Event";
-        final TestEvent event = new TestEvent(id, DateTime.parse(timestamp), eventType);
+    public void shouldLogErrorAfterFailingToEncrypt() throws Exception {
+        final String errorMessage = "Failed to encrypt.";
+        when(encrypter.encrypt(event)).thenThrow(new RuntimeException(errorMessage));
 
-        eventEmitterWithoutRecordingSystem.record(event);
+        try (ByteArrayOutputStream errorContent = new ByteArrayOutputStream();
+             PrintStream printStream = new PrintStream(errorContent)) {
+            System.setErr(printStream);
+            eventEmitter.record(event);
+            System.setErr(System.err);
 
-        assertThat(outContent.toString()).isEmpty();
+            assertThat(errorContent.toString()).contains(String.format(
+                "Failed to send a message [Event Id: %s] to the queue. Error Message: %s\nEvent Message: null\n",
+                ID,
+                errorMessage
+            ));
+        }
     }
 
     @Test
-    public void shouldNotThrowErrorsIfInputsAreNull() {
-        final TestEvent event = new TestEvent(null, null, null);
+    public void shouldLogErrorWhenEventIsNull() throws IOException {
+        try (ByteArrayOutputStream errorContent = new ByteArrayOutputStream();
+             PrintStream printStream = new PrintStream(errorContent)) {
+            System.setErr(printStream);
+            eventEmitter.record(null);
+            System.setErr(System.err);
 
-        eventEmitter.record(event);
-
-        assertThat(outContent.toString())
-            .isEqualTo("Event ID: null, Timestamp: null, Event Type: null\n");
+            assertThat(errorContent.toString()).contains("Unable to send a message due to event containing null value.\n");
+        }
     }
 }

--- a/src/test/java/uk/gov/ida/eventemitter/StubEncrypterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/StubEncrypterTest.java
@@ -1,0 +1,26 @@
+package uk.gov.ida.eventemitter;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class StubEncrypterTest {
+
+    private static final UUID ID = UUID.randomUUID();
+    private static final DateTime TIMESTAMP = DateTime.now(DateTimeZone.UTC);
+    private static final String EVENT_TYPE = "Error Event";
+
+    @Test
+    public void shouldReturnEncryptedEvent() {
+        final StubEncrypter encrypter = new StubEncrypter();
+        final TestEvent event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
+
+        final String actualValue = encrypter.encrypt(event);
+
+        assertThat(actualValue).isEqualTo(String.format("Encrypted Event Id %s", ID));
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/StubSqsClientTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/StubSqsClientTest.java
@@ -1,0 +1,65 @@
+package uk.gov.ida.eventemitter;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class StubSqsClientTest {
+
+    private static final UUID ID = UUID.randomUUID();
+    private static final DateTime TIMESTAMP = DateTime.now(DateTimeZone.UTC);
+    private static final String EVENT_TYPE = "Error Event";
+    private static final String ENCRYPTED_EVENT = "encryptedEvent";
+
+    private StubSqsClient sqsClient;
+    private Event event;
+
+    @Before
+    public void setUp() {
+        sqsClient = new StubSqsClient();
+    }
+
+    @Test
+    public void shouldWriteEventDetailsToStandardOutput() throws IOException {
+        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
+
+        try (ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+             PrintStream printStream = new PrintStream(outContent)) {
+            System.setOut(printStream);
+            sqsClient.send(event, ENCRYPTED_EVENT);
+            System.setOut(System.out);
+
+            assertThat(outContent.toString())
+                .containsOnlyOnce(String.format(
+                "Event ID: %s, Timestamp: %s, Event Type: %s, Event String: %s\n",
+                ID,
+                TIMESTAMP,
+                EVENT_TYPE,
+                ENCRYPTED_EVENT
+            ));
+        }
+    }
+
+    @Test
+    public void shouldNotThrowErrorsIfInputsAreNull() throws IOException {
+        event = new TestEvent(null, null, null);
+
+        try (ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+             PrintStream printStream = new PrintStream(outContent)) {
+            System.setOut(printStream);
+            sqsClient.send(event, "null");
+            System.setOut(System.out);
+
+            assertThat(outContent.toString())
+                .containsOnlyOnce("Event ID: null, Timestamp: null, Event Type: null, Event String: null\n");
+        }
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/TestConfiguration.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestConfiguration.java
@@ -1,0 +1,15 @@
+package uk.gov.ida.eventemitter;
+
+public class TestConfiguration implements Configuration {
+
+    private final String queueName;
+
+    public TestConfiguration(final String queueName) {
+        this.queueName = queueName;
+    }
+
+    @Override
+    public String getQueueName() {
+        return queueName;
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/TestEvent.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestEvent.java
@@ -1,14 +1,23 @@
 package uk.gov.ida.eventemitter;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.DateTime;
 
+import java.util.Objects;
 import java.util.UUID;
 
-public class TestEvent implements Event {
+public final class TestEvent implements Event {
 
-    private final UUID eventId;
-    private final DateTime timestamp;
-    private final String eventType;
+    @JsonProperty
+    private UUID eventId;
+
+    @JsonProperty
+    private DateTime timestamp;
+
+    @JsonProperty
+    private String eventType;
+
+    private TestEvent() {}
 
     public TestEvent(final UUID eventId, final DateTime timestamp, final String eventType) {
         this.eventId = eventId;
@@ -29,5 +38,37 @@ public class TestEvent implements Event {
     @Override
     public String getEventType() {
         return eventType;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuffer sb = new StringBuffer("TestEvent{");
+        sb.append("eventId=").append(eventId);
+        sb.append(", timestamp=").append(timestamp);
+        sb.append(", eventType='").append(eventType).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TestEvent testEvent = (TestEvent) o;
+
+        return Objects.equals(eventId, testEvent.eventId) &&
+            Objects.equals(timestamp, testEvent.timestamp) &&
+            Objects.equals(eventType, testEvent.eventType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId, timestamp, eventType);
     }
 }

--- a/src/test/java/uk/gov/ida/eventemitter/TestEventEmitterModule.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestEventEmitterModule.java
@@ -1,0 +1,28 @@
+package uk.gov.ida.eventemitter;
+
+import cloud.localstack.TestUtils;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+
+import java.util.Optional;
+
+public class TestEventEmitterModule extends AbstractModule {
+
+    private Configuration configuration;
+
+    public TestEventEmitterModule(Configuration configuration) {
+        this.configuration = configuration;
+    }
+
+    @Override
+    protected void configure() {}
+
+    @Provides
+    private Optional<AmazonSQS> getAmazonSqs() {
+        if (this.configuration.getQueueName() != null) {
+            return Optional.ofNullable(TestUtils.getClientSQS());
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
These changes enable Event Emitter to encrypt event messages using stub encryption or Amazon encryption service. They also allow Event Emitter to send encrypted messages to either stub SQS service or Amazon SQS service.

Authors: @adityapahuja @michaelwalker