### PR TITLE
ABD-35: Add further test cases to Event Emitter

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/Configuration.java
+++ b/src/main/java/uk/gov/ida/eventemitter/Configuration.java
@@ -2,5 +2,5 @@ package uk.gov.ida.eventemitter;
 
 public interface Configuration {
 
-    String getQueueName();
+    String getSourceQueueName();
 }

--- a/src/main/java/uk/gov/ida/eventemitter/Encrypter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/Encrypter.java
@@ -1,8 +1,6 @@
 package uk.gov.ida.eventemitter;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
 public interface Encrypter {
 
-    String encrypt(final Event event) throws JsonProcessingException;
+    String encrypt(final Event event) throws Exception;
 }

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -10,18 +10,12 @@ import java.util.Optional;
 
 public class EventEmitterModule extends AbstractModule {
 
-    private Configuration configuration;
-
-    public EventEmitterModule(Configuration configuration) {
-        this.configuration = configuration;
-    }
-
     @Override
     protected void configure() {}
 
     @Provides
-    private Optional<AmazonSQS> getAmazonSqs() {
-        if (this.configuration.getQueueName() != null) {
+    private Optional<AmazonSQS> getAmazonSqs(final Optional<Configuration> configuration) {
+        if (configuration.isPresent() && configuration.get().getQueueName() != null) {
             return Optional.ofNullable(AmazonSQSClientBuilder.defaultClient());
         }
         return Optional.empty();
@@ -29,8 +23,9 @@ public class EventEmitterModule extends AbstractModule {
 
     @Provides
     @Named("QueueUrl")
-    private Optional<String> getQueueUrl(final Optional<AmazonSQS> amazonSqs) {
-        return amazonSqs.map(sqs -> sqs.getQueueUrl(configuration.getQueueName()).getQueueUrl());
+    private Optional<String> getQueueUrl(final Optional<AmazonSQS> amazonSqs,
+                                         final Optional<Configuration> configuration) {
+        return amazonSqs.map(sqs -> sqs.getQueueUrl(configuration.get().getQueueName()).getQueueUrl());
     }
 
     @Provides

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -15,24 +15,24 @@ public class EventEmitterModule extends AbstractModule {
 
     @Provides
     private Optional<AmazonSQS> getAmazonSqs(final Optional<Configuration> configuration) {
-        if (configuration.isPresent() && configuration.get().getQueueName() != null) {
+        if (configuration.isPresent() && configuration.get().getSourceQueueName() != null) {
             return Optional.ofNullable(AmazonSQSClientBuilder.defaultClient());
         }
         return Optional.empty();
     }
 
     @Provides
-    @Named("QueueUrl")
+    @Named("SourceQueueUrl")
     private Optional<String> getQueueUrl(final Optional<AmazonSQS> amazonSqs,
                                          final Optional<Configuration> configuration) {
-        return amazonSqs.map(sqs -> sqs.getQueueUrl(configuration.get().getQueueName()).getQueueUrl());
+        return amazonSqs.map(sqs -> sqs.getQueueUrl(configuration.get().getSourceQueueName()).getQueueUrl());
     }
 
     @Provides
     private SqsClient getAmazonSqsClient(final Optional<AmazonSQS> amazonSqs,
-                                         final @Named("QueueUrl") Optional<String> queueUrl) {
-        if (amazonSqs.isPresent() && queueUrl.isPresent()){
-            return new AmazonSqsClient(amazonSqs.get(), queueUrl.get());
+                                         final @Named("SourceQueueUrl") Optional<String> sourceQueueUrl) {
+        if (amazonSqs.isPresent() && sourceQueueUrl.isPresent()){
+            return new AmazonSqsClient(amazonSqs.get(), sourceQueueUrl.get());
         }
         return new StubSqsClient();
     }

--- a/src/test/java/uk/gov/ida/eventemitter/AmazonEncrypterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/AmazonEncrypterTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -40,10 +41,13 @@ public class AmazonEncrypterTest {
     @Mock
     private CryptoResult cryptoResult;
 
+
     @Test
     public void shouldEncryptEvent() throws JsonProcessingException {
+        final Map<String, String> details = new HashMap<>();
+        details.put("type", "network error");
+        final TestEvent event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE, details);
         final AmazonEncrypter encrypter = new AmazonEncrypter(awsCrypto, provider, mapper);
-        final TestEvent event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
         final Map<String, String> context = Collections.EMPTY_MAP;
 
         when(mapper.writeValueAsString(event)).thenReturn(JSON_STRING);

--- a/src/test/java/uk/gov/ida/eventemitter/AmazonSqsClientIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/AmazonSqsClientIntegrationTest.java
@@ -1,0 +1,88 @@
+package uk.gov.ida.eventemitter;
+
+import cloud.localstack.LocalstackTestRunner;
+import cloud.localstack.TestUtils;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.model.AmazonSQSException;
+import com.amazonaws.services.sqs.model.CreateQueueRequest;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(LocalstackTestRunner.class)
+public class AmazonSqsClientIntegrationTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    private static final UUID ID = UUID.randomUUID();
+    private static final DateTime TIMESTAMP = DateTime.now(DateTimeZone.UTC);
+    private static final String EVENT_TYPE = "Error Event";
+    private static final String ENCRYPTED_EVENT = "encryptedEvent";
+    private static final String QUEUE_NAME = "queueName";
+
+    private static AmazonSQS sqs;
+    private static AmazonSqsClient sqsClient;
+    private static String queueUrl;
+    private static Event event;
+
+    @BeforeClass
+    public static void setUp() {
+        final Map<String, String> details = new HashMap<>();
+        details.put("type", "network error");
+        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE, details);
+
+        sqs = TestUtils.getClientSQS();
+        sqs.createQueue(new CreateQueueRequest(QUEUE_NAME));
+        queueUrl = sqs.getQueueUrl(QUEUE_NAME).getQueueUrl();
+        sqsClient = new AmazonSqsClient(sqs, queueUrl);
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        sqs.deleteQueue(queueUrl);
+    }
+
+    @Test
+    public void shouldSendEventToSqs() {
+        sqsClient = new AmazonSqsClient(sqs, queueUrl);
+
+        sqsClient.send(event, ENCRYPTED_EVENT);
+
+        final ReceiveMessageRequest receiveMessageRequest = new ReceiveMessageRequest(queueUrl);
+        final List<Message> messages = sqs.receiveMessage(receiveMessageRequest).getMessages();
+
+        assertThat(messages.size()).isEqualTo(1);
+        final Message message = messages.get(0);
+        sqs.deleteMessage(queueUrl, message.getReceiptHandle());
+
+        assertThat(message.getBody()).isEqualTo(ENCRYPTED_EVENT);
+    }
+
+    @Test
+    public void shouldThrowErrorWhenSendingMessageToSqsWhereQueueDoesNotExist() {
+        expectedException.expect(AmazonSQSException.class);
+        expectedException.expectMessage("Invalid request: MissingQueryParamRejection(QueueName), " +
+            "MissingQueryParamRejection(QueueUrl); see the SQS docs. (Service: AmazonSQS; Status Code: 400; Error " +
+            "Code: Invalid request: MissingQueryParamRejection(QueueName), MissingQueryParamRejection(QueueUrl); " +
+            "Request ID: 00000000-0000-0000-0000-000000000000)");
+
+        sqsClient = new AmazonSqsClient(sqs, "nonExistentQueueUrl");
+
+        sqsClient.send(event, ENCRYPTED_EVENT);
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/AmazonSqsClientTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/AmazonSqsClientTest.java
@@ -12,6 +12,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.mockito.Mockito.verify;
@@ -43,7 +45,9 @@ public class AmazonSqsClientTest {
 
     @Test
     public void shouldSendEventToSqs() {
-        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
+        final Map<String, String> details = new HashMap<>();
+        details.put("type", "network error");
+        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE, details);
         final SendMessageResult result = new SendMessageResult();
         when(sqs.sendMessage(SEND_MESSAGE_REQUEST)).thenReturn(result);
 

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -5,9 +5,12 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.CreateQueueRequest;
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
+import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import com.google.inject.util.Modules;
@@ -19,25 +22,36 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static uk.gov.ida.eventemitter.TestEventEmitterModule.INIT_VECTOR;
+import static uk.gov.ida.eventemitter.TestEventEmitterModule.KEY;
 
 @RunWith(LocalstackTestRunner.class)
 public class EventEmitterIntegrationTest {
 
     private static final String QUEUE_NAME = "queueName";
-    private static final TestConfiguration CONFIGURATION = new TestConfiguration(QUEUE_NAME);
     private static Injector injector;
     private static Optional<String> queueUrl;
     private static Optional<AmazonSQS> clientSqs;
 
     @BeforeClass
     public static void setUp() {
-        injector = Guice.createInjector(Modules.override(new EventEmitterModule(CONFIGURATION))
-            .with(new TestEventEmitterModule(CONFIGURATION)));
+        injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {}
+
+            @Provides
+            private Optional<Configuration> getConfiguration() {
+                return Optional.ofNullable(new TestConfiguration(QUEUE_NAME));
+            }
+        }, Modules.override(new EventEmitterModule())
+            .with(new TestEventEmitterModule()));
         clientSqs = (Optional<AmazonSQS>) injector.getInstance(
             Key.get(TypeLiteral.get(Types.newParameterizedType(Optional.class, AmazonSQS.class))));
         clientSqs.get().createQueue(new CreateQueueRequest(QUEUE_NAME));
@@ -51,16 +65,20 @@ public class EventEmitterIntegrationTest {
     }
 
     @Test
-    public void shouldEncryptMessageAndSendToSQS() {
+    public void shouldEncryptMessageAndSendToSQS() throws Exception {
         final EventEmitter eventEmitter = injector.getInstance(EventEmitter.class);
-        final Event event = new TestEvent(UUID.randomUUID(), DateTime.now(DateTimeZone.UTC), "eventType");
+        final Map<String, String> details = new HashMap<>();
+        details.put("type", "network error");
+        final Event event = new TestEvent(UUID.randomUUID(), DateTime.now(DateTimeZone.UTC), "eventType", details);
 
         eventEmitter.record(event);
 
         final Message message = getAnEncryptedMessageFromSqs();
         clientSqs.get().deleteMessage(queueUrl.get(), message.getReceiptHandle());
+        final TestDecrypter<TestEvent> decrypter = new TestDecrypter(KEY, INIT_VECTOR, injector.getInstance(ObjectMapper.class));
+        final Event actualEvent = decrypter.decrypt(message.getBody(), TestEvent.class);
 
-        assertThat(message.getBody()).isEqualTo(String.format("Encrypted Event Id %s", event.getEventId().toString()));
+        assertThat(actualEvent).isEqualTo(event);
     }
 
     private Message getAnEncryptedMessageFromSqs() {

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterTest.java
@@ -11,6 +11,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
@@ -36,7 +38,9 @@ public class EventEmitterTest {
 
     @Before
     public void setUp() throws Exception {
-        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
+        final Map<String, String> details = new HashMap<>();
+        details.put("type", "network error");
+        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE, details);
         when(encrypter.encrypt(event)).thenReturn(ENCRYPTED_EVENT);
 
         eventEmitter = new EventEmitter(encrypter, sqsClient);

--- a/src/test/java/uk/gov/ida/eventemitter/StubEncrypterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/StubEncrypterTest.java
@@ -4,6 +4,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -17,7 +19,9 @@ public class StubEncrypterTest {
     @Test
     public void shouldReturnEncryptedEvent() {
         final StubEncrypter encrypter = new StubEncrypter();
-        final TestEvent event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
+        final Map<String, String> details = new HashMap<>();
+        details.put("type", "network error");
+        final TestEvent event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE, details);
 
         final String actualValue = encrypter.encrypt(event);
 

--- a/src/test/java/uk/gov/ida/eventemitter/StubSqsClientTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/StubSqsClientTest.java
@@ -8,6 +8,8 @@ import org.junit.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -29,7 +31,9 @@ public class StubSqsClientTest {
 
     @Test
     public void shouldWriteEventDetailsToStandardOutput() throws IOException {
-        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE);
+        final Map<String, String> details = new HashMap<>();
+        details.put("type", "network error");
+        event = new TestEvent(ID, TIMESTAMP, EVENT_TYPE, details);
 
         try (ByteArrayOutputStream outContent = new ByteArrayOutputStream();
              PrintStream printStream = new PrintStream(outContent)) {
@@ -50,7 +54,7 @@ public class StubSqsClientTest {
 
     @Test
     public void shouldNotThrowErrorsIfInputsAreNull() throws IOException {
-        event = new TestEvent(null, null, null);
+        event = new TestEvent(null, null, null, null);
 
         try (ByteArrayOutputStream outContent = new ByteArrayOutputStream();
              PrintStream printStream = new PrintStream(outContent)) {

--- a/src/test/java/uk/gov/ida/eventemitter/TestConfiguration.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestConfiguration.java
@@ -2,14 +2,14 @@ package uk.gov.ida.eventemitter;
 
 public class TestConfiguration implements Configuration {
 
-    private final String queueName;
+    private final String sourceQueueName;
 
-    public TestConfiguration(final String queueName) {
-        this.queueName = queueName;
+    public TestConfiguration(final String sourceQueueName) {
+        this.sourceQueueName = sourceQueueName;
     }
 
     @Override
-    public String getQueueName() {
-        return queueName;
+    public String getSourceQueueName() {
+        return sourceQueueName;
     }
 }

--- a/src/test/java/uk/gov/ida/eventemitter/TestDecrypter.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestDecrypter.java
@@ -1,0 +1,34 @@
+package uk.gov.ida.eventemitter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import org.apache.commons.codec.binary.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class TestDecrypter<T> {
+
+    private final String key;
+    private final String initVector;
+    private final ObjectMapper mapper;
+
+    @Inject
+    public TestDecrypter(final String key,
+                         final String initVector,
+                         final ObjectMapper mapper) {
+        this.key = key;
+        this.initVector = initVector;
+        this.mapper = mapper;
+    }
+
+    public T decrypt(final String encryptedEvent, final Class<T> klass) throws Exception {
+        final IvParameterSpec iv = new IvParameterSpec(initVector.getBytes("UTF-8"));
+        final SecretKeySpec skeySpec = new SecretKeySpec(key.getBytes("UTF-8"), "AES");
+        final Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+        cipher.init(Cipher.DECRYPT_MODE, skeySpec, iv);
+        final byte[] original = cipher.doFinal(Base64.decodeBase64(encryptedEvent));
+        return (T) mapper.readValue(original, klass);
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/TestEncrypter.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestEncrypter.java
@@ -1,0 +1,35 @@
+package uk.gov.ida.eventemitter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Inject;
+import org.apache.commons.codec.binary.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class TestEncrypter implements Encrypter {
+
+    private final String key;
+    private final String initVector;
+    private final ObjectMapper mapper;
+
+    @Inject
+    public TestEncrypter(final String key,
+                         final String initVector,
+                         final ObjectMapper mapper) {
+        this.key = key;
+        this.initVector = initVector;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String encrypt(final Event event) throws Exception {
+        final IvParameterSpec iv = new IvParameterSpec(initVector.getBytes("UTF-8"));
+        final SecretKeySpec skeySpec = new SecretKeySpec(key.getBytes("UTF-8"), "AES");
+        final Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5PADDING");
+        cipher.init(Cipher.ENCRYPT_MODE, skeySpec, iv);
+        final byte[] encryptedEvent = cipher.doFinal(mapper.writeValueAsBytes(event));
+        return Base64.encodeBase64String(encryptedEvent);
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/TestEvent.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestEvent.java
@@ -3,6 +3,7 @@ package uk.gov.ida.eventemitter;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.DateTime;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -17,12 +18,19 @@ public final class TestEvent implements Event {
     @JsonProperty
     private String eventType;
 
+    @JsonProperty
+    private Map<String, String> details;
+
     private TestEvent() {}
 
-    public TestEvent(final UUID eventId, final DateTime timestamp, final String eventType) {
+    public TestEvent(final UUID eventId,
+                     final DateTime timestamp,
+                     final String eventType,
+                     final Map<String, String> details) {
         this.eventId = eventId;
         this.timestamp = timestamp;
         this.eventType = eventType;
+        this.details = details;
     }
 
     @Override
@@ -40,12 +48,17 @@ public final class TestEvent implements Event {
         return eventType;
     }
 
+    public Map<String, String> getDetails() {
+        return details;
+    }
+
     @Override
     public String toString() {
         final StringBuffer sb = new StringBuffer("TestEvent{");
         sb.append("eventId=").append(eventId);
         sb.append(", timestamp=").append(timestamp);
         sb.append(", eventType='").append(eventType).append('\'');
+        sb.append(", details=").append(details);
         sb.append('}');
         return sb.toString();
     }
@@ -64,11 +77,12 @@ public final class TestEvent implements Event {
 
         return Objects.equals(eventId, testEvent.eventId) &&
             Objects.equals(timestamp, testEvent.timestamp) &&
-            Objects.equals(eventType, testEvent.eventType);
+            Objects.equals(eventType, testEvent.eventType) &&
+            Objects.equals(details, testEvent.details);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(eventId, timestamp, eventType);
+        return Objects.hash(eventId, timestamp, eventType, details);
     }
 }

--- a/src/test/java/uk/gov/ida/eventemitter/TestEventEmitterModule.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestEventEmitterModule.java
@@ -19,7 +19,7 @@ public class TestEventEmitterModule extends AbstractModule {
 
     @Provides
     private Optional<AmazonSQS> getAmazonSqs(final Optional<Configuration> configuration) {
-        if (configuration.isPresent() && configuration.get().getQueueName() != null) {
+        if (configuration.isPresent() && configuration.get().getSourceQueueName() != null) {
             return Optional.ofNullable(TestUtils.getClientSQS());
         }
         return Optional.empty();


### PR DESCRIPTION
Update to test an additional field of TestEvent not present in Event interface to ensure that this field is present before and after sending to SQS.
Add TestEncrypter and TestDecrypter to enable an integration test to be able to encrypt an event and decrypt the event properly.
Update EventEmitterModule to drop its attribute Configuration since Configuration cannot be passed through EventEmitterModule's constructor parameter via install() method. @Provides Methods get Configuration via their parameters instead.
Add an integration test to test AmazonSqsClient class. The new integration test tests the failure of sending event message to SQS.
Rename queueName to sourceQueueName to highlight that it is not a dead letter queue.

Authors: @adityapahuja