### PR TITLE
bau: Use docker in pre-commit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+logs/*
+build
+.gradle
+.npm
+

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ out/
 *~
 *#
 target
+/.cache/
+/.localstack
+/.npm/
+/logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,6 @@ COPY gradlew gradlew
 RUN ./gradlew --no-daemon
 
 COPY build.gradle build.gradle
-RUN ./gradlew --no-daemon dependencies
+RUN ./gradlew --no-daemon resolveDependencies
 
 COPY . ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,22 @@ FROM govukverify/java8:latest
 RUN apt-get update \
     && apt-get install -y python-pip build-essential maven sudo \
     && curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - \
-    && apt-get install -y nodejs
+    && apt-get install -y nodejs \
+    && pip install virtualenv
 
-RUN pip install virtualenv
-
-RUN groupadd -g 116 team
-RUN useradd -r -u 109 -g 116 user
 WORKDIR /home/user
-RUN chown -R user:116 /home/user
-RUN chmod 755 /home/user
+RUN groupadd -g 116 team;\
+    useradd -r -u 109 -g 116 user;\
+    chown -R user:116 /home/user;\
+    chmod 755 /home/user
+
 USER user
+
+COPY gradle gradle
+COPY gradlew gradlew
+RUN ./gradlew --no-daemon
+
+COPY build.gradle build.gradle
+RUN ./gradlew --no-daemon dependencies
+
+COPY . ./

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,13 @@ dependencies {
                 'cloud.localstack:localstack-utils:0.1.9'
 }
 
+task resolveDependencies {
+    doLast {
+        project.rootProject.configurations['compile'].resolve()
+        project.rootProject.configurations['testCompile'].resolve()
+    }
+}
+
 task sourceJar(type: Jar) {
     from sourceSets.main.allJava
 }

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -29,6 +29,6 @@ else
   docker build -t verify-event-emitter .
 
   echo "${blue}Running tests in docker.${reset}"
-  docker run --rm --entrypoint './gradlew' verify-event-emitter --no-daemon clean build
+  docker run --rm --entrypoint './gradlew' verify-event-emitter --no-daemon --offline clean build
 fi
 

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,3 +1,34 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
-./gradlew clean build
+set -eu
+
+yellow=$(tput setaf 3)
+blue=$(tput setaf 4)
+reset=$(tput sgr0)
+
+no_docker=false
+for arg in "$@"
+do
+  case "$arg" in
+    --no-docker)
+      no_docker=true
+      ;;
+  esac
+done
+
+if [ "$no_docker" = true ]
+then
+  ./gradlew clean build
+else
+  >&2 echo -n "$yellow"
+  >&2 echo 'Running tests in docker to avoid having to install python dependencies on your host'
+  >&2 echo 'To suppress this behaviour pass the --no-docker command line argument'
+  >&2 echo -n "$reset"
+
+  echo "${blue}Building your docker image...${reset}"
+  docker build -t verify-event-emitter .
+
+  echo "${blue}Running tests in docker.${reset}"
+  docker run --rm --entrypoint './gradlew' verify-event-emitter --no-daemon clean build
+fi
+


### PR DESCRIPTION
I was pretty surprised to see the tests in this (java) project attempt to
download a bunch of python and JS dependencies. Needless to say, my host OS
is not set up with the exact set of versions to install these deps, so the
build fails. Seems like this would be a good use of docker.