### PR TITLE
bau: Nicer / more robust way of downloading deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,10 +22,11 @@ dependencies {
                 'cloud.localstack:localstack-utils:0.1.9'
 }
 
-task resolveDependencies {
-    doLast {
-        project.rootProject.configurations['compile'].resolve()
-        project.rootProject.configurations['testCompile'].resolve()
+allprojects {
+    task resolveDependencies {
+        doLast {
+            configurations.all { it.isCanBeResolved() && it.resolve() }
+        }
     }
 }
 


### PR DESCRIPTION
Before we would have missed any deps other than the ones from the root
project's compile and testCompile. This should get them all, regardless
of project structure.