### PR TITLE
335 Decrypt an event encryption key and override AWS credentials in environment variables

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/Configuration.java
+++ b/src/main/java/uk/gov/ida/eventemitter/Configuration.java
@@ -1,6 +1,14 @@
 package uk.gov.ida.eventemitter;
 
+import com.amazonaws.regions.Regions;
+
 public interface Configuration {
+
+    String getAccessKeyId();
+
+    String getSecretAccessKey();
+
+    Regions getRegion();
 
     String getSourceQueueName();
 

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -1,19 +1,26 @@
 package uk.gov.ida.eventemitter;
 
 import com.amazonaws.SdkClientException;
+import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
+import com.amazonaws.services.kms.model.DecryptRequest;
+import com.amazonaws.services.kms.model.DecryptResult;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.util.Base64;
 import com.amazonaws.util.IOUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Optional;
 
 public class EventEmitterModule extends AbstractModule {
@@ -22,6 +29,7 @@ public class EventEmitterModule extends AbstractModule {
     protected void configure() {}
 
     @Provides
+    @Singleton
     private Optional<AmazonSQS> getAmazonSqs(final Optional<Configuration> configuration) {
         if (configuration.isPresent() &&
             configuration.get().getSourceQueueName() != null) {
@@ -31,6 +39,7 @@ public class EventEmitterModule extends AbstractModule {
     }
 
     @Provides
+    @Singleton
     private Optional<AmazonS3> getAmazonS3(final Optional<Configuration> configuration) {
         if (configuration.isPresent() &&
             configuration.get().getBucketName() != null &&
@@ -41,6 +50,7 @@ public class EventEmitterModule extends AbstractModule {
     }
 
     @Provides
+    @Singleton
     @Named("SourceQueueUrl")
     private Optional<String> getQueueUrl(final Optional<AmazonSQS> amazonSqs,
                                          final Optional<Configuration> configuration) {
@@ -48,6 +58,7 @@ public class EventEmitterModule extends AbstractModule {
     }
 
     @Provides
+    @Singleton
     private SqsClient getAmazonSqsClient(final Optional<AmazonSQS> amazonSqs,
                                          final @Named("SourceQueueUrl") Optional<String> sourceQueueUrl) {
         if (amazonSqs.isPresent() && sourceQueueUrl.isPresent()){
@@ -57,16 +68,26 @@ public class EventEmitterModule extends AbstractModule {
     }
 
     @Provides
+    @Singleton
+    private Optional<AWSKMS> getAmazonKms(Optional<AmazonS3> amazonS3) {
+        return amazonS3.map(s3 -> AWSKMSClientBuilder.defaultClient());
+    }
+
+    @Provides
+    @Singleton
     private Encrypter getEncrypter(final Optional<AmazonS3> amazonS3,
                                    final Optional<Configuration> configuration,
-                                   final ObjectMapper mapper) {
-        if (amazonS3.isPresent()) {
+                                   final ObjectMapper mapper,
+                                   final Optional<AWSKMS> amazonKms) {
+        if (amazonS3.isPresent() && amazonKms.isPresent()) {
             try {
                 S3Object s3Object = amazonS3.get().getObject(configuration.get().getBucketName(), configuration.get().getKeyName());
-                S3ObjectInputStream s3ObjectInputStream = s3Object.getObjectContent();
-                byte[] key = IOUtils.toByteArray(s3ObjectInputStream);
-                return new EventEncrypter(key, mapper);
+                try (S3ObjectInputStream s3ObjectInputStream = s3Object.getObjectContent();) {
+                    DecryptRequest request = new DecryptRequest().withCiphertextBlob(ByteBuffer.wrap(Base64.decode(IOUtils.toString(s3ObjectInputStream))));
+                    DecryptResult key = amazonKms.get().decrypt(request);
 
+                    return new EventEncrypter(key.getPlaintext().array(), mapper);
+                }
             } catch (SdkClientException e) {
                 System.err.println(
                     String.format("Failed to load S3 bucket %s.", configuration.get().getBucketName()));
@@ -80,6 +101,7 @@ public class EventEmitterModule extends AbstractModule {
     }
 
     @Provides
+    @Singleton
     private EventEmitter getEventEmitter(final SqsClient sqsClient,
                                          final Encrypter encrypter) {
         return new EventEmitter(encrypter, sqsClient);

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -1,6 +1,9 @@
 package uk.gov.ida.eventemitter;
 
 import cloud.localstack.LocalstackTestRunner;
+import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.model.DecryptRequest;
+import com.amazonaws.services.kms.model.DecryptResult;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.Message;
@@ -9,6 +12,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 import com.google.inject.util.Modules;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -17,12 +21,16 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(LocalstackTestRunner.class)
 public class EventEmitterIntegrationTest {
@@ -38,15 +46,20 @@ public class EventEmitterIntegrationTest {
 
     @BeforeClass
     public static void setUp() {
+        AWSKMS awsKms = mock(AWSKMS.class);
+        DecryptResult decryptResult = mock(DecryptResult.class);
+        when(awsKms.decrypt(any(DecryptRequest.class))).thenReturn(decryptResult);
+        when(decryptResult.getPlaintext()).thenReturn(ByteBuffer.wrap(KEY.getBytes()));
         injector = Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {}
 
             @Provides
+            @Singleton
             private Optional<Configuration> getConfiguration() {
                 return Optional.ofNullable(new TestConfiguration(SOURCE_QUEUE_NAME, BUCKET_NAME, KEY_NAME));
             }
-        }, Modules.override(new EventEmitterModule()).with(new TestEventEmitterModule()));
+        }, Modules.override(new EventEmitterModule()).with(new TestEventEmitterModule(awsKms)));
 
         sqs = AmazonHelper.getInstanceOfAmazonSqs(injector);
         s3 = AmazonHelper.getInstanceOfAmazonS3(injector);

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.eventemitter;
 
 import cloud.localstack.LocalstackTestRunner;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.model.DecryptRequest;
 import com.amazonaws.services.kms.model.DecryptResult;
@@ -35,6 +36,8 @@ import static org.mockito.Mockito.when;
 @RunWith(LocalstackTestRunner.class)
 public class EventEmitterIntegrationTest {
 
+    private static final String ACCESS_KEY_ID = "accessKeyId";
+    private static final String ACCESS_SECRET_KEY = "accessSecretKey";
     private static final String KEY = "aesEncryptionKey";
     private static final String SOURCE_QUEUE_NAME = "sourceQueueName";
     private static final String BUCKET_NAME = "bucket.name";
@@ -57,7 +60,7 @@ public class EventEmitterIntegrationTest {
             @Provides
             @Singleton
             private Optional<Configuration> getConfiguration() {
-                return Optional.ofNullable(new TestConfiguration(SOURCE_QUEUE_NAME, BUCKET_NAME, KEY_NAME));
+                return Optional.ofNullable(new TestConfiguration(ACCESS_KEY_ID, ACCESS_SECRET_KEY, Regions.EU_WEST_2, SOURCE_QUEUE_NAME, BUCKET_NAME, KEY_NAME));
             }
         }, Modules.override(new EventEmitterModule()).with(new TestEventEmitterModule(awsKms)));
 

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithAMissingS3BucketIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithAMissingS3BucketIntegrationTest.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.eventemitter;
 
 import cloud.localstack.LocalstackTestRunner;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.model.DecryptRequest;
 import com.amazonaws.services.kms.model.DecryptResult;
@@ -36,6 +37,8 @@ import static org.mockito.Mockito.when;
 @RunWith(LocalstackTestRunner.class)
 public class EventEmitterWithAMissingS3BucketIntegrationTest {
 
+    private static final String ACCESS_KEY_ID = "accessKeyId";
+    private static final String ACCESS_SECRET_KEY = "accessSecretKey";
     private static final String KEY = "aesEncryptionKey";
     private static final String SOURCE_QUEUE_NAME = "sourceQueueName";
     private static final String BUCKET_NAME = "bucket.name";
@@ -62,7 +65,7 @@ public class EventEmitterWithAMissingS3BucketIntegrationTest {
 
             @Provides
             private Optional<Configuration> getConfiguration() {
-                return Optional.ofNullable(new TestConfiguration(SOURCE_QUEUE_NAME, BUCKET_NAME, KEY_NAME));
+                return Optional.ofNullable(new TestConfiguration(ACCESS_KEY_ID, ACCESS_SECRET_KEY, Regions.EU_WEST_2, SOURCE_QUEUE_NAME, BUCKET_NAME, KEY_NAME));
             }
         }, Modules.override(new EventEmitterModule()).with(new TestEventEmitterModule(awsKms)));
 

--- a/src/test/java/uk/gov/ida/eventemitter/TestConfiguration.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestConfiguration.java
@@ -1,17 +1,45 @@
 package uk.gov.ida.eventemitter;
 
-public class TestConfiguration implements Configuration {
+import com.amazonaws.regions.Regions;
 
+public final class TestConfiguration implements Configuration {
+
+    private final String accessKeyId;
+    private final String accessSecretKey;
+    private final Regions region;
     private final String sourceQueueName;
     private final String bucketName;
     private final String keyName;
 
-    public TestConfiguration(final String sourceQueueName,
-                             final String bucketName,
-                             final String keyName) {
+    public TestConfiguration(
+        final String accessKeyId,
+        final String accessSecretKey,
+        final Regions region,
+        final String sourceQueueName,
+        final String bucketName,
+        final String keyName) {
+
+        this.accessKeyId = accessKeyId;
+        this.accessSecretKey = accessSecretKey;
+        this.region = region;
         this.sourceQueueName = sourceQueueName;
         this.bucketName = bucketName;
         this.keyName = keyName;
+    }
+
+    @Override
+    public String getAccessKeyId() {
+        return accessKeyId;
+    }
+
+    @Override
+    public String getSecretAccessKey() {
+        return accessSecretKey;
+    }
+
+    @Override
+    public Regions getRegion() {
+        return region;
     }
 
     @Override

--- a/src/test/java/uk/gov/ida/eventemitter/TestEventEmitterModule.java
+++ b/src/test/java/uk/gov/ida/eventemitter/TestEventEmitterModule.java
@@ -1,20 +1,30 @@
 package uk.gov.ida.eventemitter;
 
 import cloud.localstack.TestUtils;
+import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
+import com.google.inject.Singleton;
 
 import java.util.Optional;
 
 public class TestEventEmitterModule extends AbstractModule {
+
+    private final AWSKMS awsKms;
+
+    public TestEventEmitterModule(AWSKMS awsKms) {
+        this.awsKms = awsKms;
+    }
+
     @Override
     protected void configure() {}
 
     @Provides
+    @Singleton
     private Optional<AmazonSQS> getAmazonSqs(final Optional<Configuration> configuration) {
         if (configuration.isPresent() && configuration.get().getSourceQueueName() != null) {
             return Optional.ofNullable(TestUtils.getClientSQS());
@@ -23,6 +33,7 @@ public class TestEventEmitterModule extends AbstractModule {
     }
 
     @Provides
+    @Singleton
     private Optional<AmazonS3> getAmazonS3(final Optional<Configuration> configuration) {
         if (configuration.isPresent() &&
             configuration.get().getBucketName() != null &&
@@ -33,6 +44,13 @@ public class TestEventEmitterModule extends AbstractModule {
     }
 
     @Provides
+    @Singleton
+    private Optional<AWSKMS> getAmazonKms(Optional<AmazonS3> amazonS3) {
+        return amazonS3.map(s3 -> awsKms);
+    }
+
+    @Provides
+    @Singleton
     private ObjectMapper getObjectMapper() {
         ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new JodaModule());


### PR DESCRIPTION
Change an event emitter to initialise once e.g. to decrypt an event encryption key once after fetching it. Update integration tests to include AWS KMS. LocalStack does not have AWS KMS and it requires integration tests to have mock AWS KMS which can decrypt an event encryption key.

Update an event emitter to override AWS credentials in environment variables if required. It ensures that the event emitter uses its AWS credentials instead of a developer's AWS credentials.

Authors: @adityapahuja
