### PR TITLE
Trello-8Xm7DiDy: Add enabled flag to config.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 dependencies {
     compile     'joda-time:joda-time:2.9.9',
                 'com.google.inject:guice:4.0',
+                'com.google.code.findbugs:jsr305:1.3.9',
                 'com.amazonaws:aws-java-sdk-sqs:1.11.277',
                 'com.amazonaws:aws-java-sdk-s3:1.11.277',
                 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.8.10'

--- a/src/main/java/uk/gov/ida/eventemitter/Configuration.java
+++ b/src/main/java/uk/gov/ida/eventemitter/Configuration.java
@@ -3,6 +3,7 @@ package uk.gov.ida.eventemitter;
 import com.amazonaws.regions.Regions;
 
 public interface Configuration {
+    boolean isEnabled();
 
     String getAccessKeyId();
 

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterConfigurationException.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterConfigurationException.java
@@ -1,0 +1,7 @@
+package uk.gov.ida.eventemitter;
+
+public class EventEmitterConfigurationException extends RuntimeException {
+    public EventEmitterConfigurationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -24,7 +24,6 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.Optional;
 
 public class EventEmitterModule extends AbstractModule {
 
@@ -33,122 +32,102 @@ public class EventEmitterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private Optional<AWSCredentials> getAmazonCredential(final Optional<Configuration> configuration) {
-        return configuration.map(
-            config -> {
-                if (config.getAccessKeyId() != null && config.getSecretAccessKey() != null) {
-                    return new BasicAWSCredentials(config.getAccessKeyId(), config.getSecretAccessKey());
-                }
-                return null;
-            });
+    private AWSCredentials getAmazonCredential(final Configuration configuration) {
+        if (configuration.isEnabled()) {
+            return new BasicAWSCredentials(configuration.getAccessKeyId(), configuration.getSecretAccessKey());
+        }
+        return null;
     }
 
     @Provides
     @Singleton
-    private Optional<AmazonSQS> getAmazonSqs(
-        final Optional<Configuration> configuration,
-        final Optional<AWSCredentials> credentials) {
+    private AmazonSQS getAmazonSqs(
+            final Configuration configuration,
+            final AWSCredentials credentials) {
+        if (configuration.isEnabled()) {
+            return AmazonSQSClientBuilder.standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                    .withRegion(configuration.getRegion())
+                    .build();
+        }
+        return null;
+    }
 
-        return configuration.map(
-            config -> {
-                if (config.getSourceQueueName() != null) {
-                    if (hasAmazonCredentialWithARegion(credentials, configuration)) {
-                        return AmazonSQSClientBuilder.standard()
-                                                     .withCredentials(new AWSStaticCredentialsProvider(credentials.get()))
-                                                     .withRegion(config.getRegion())
-                                                     .build();
-                    }
-                    return AmazonSQSClientBuilder.defaultClient();
-                }
-                return null;
-            });
+    @Provides
+    @Singleton
+    private AmazonS3 getAmazonS3(
+            final Configuration configuration,
+            final AWSCredentials credentials) {
+        if (configuration.isEnabled()) {
+            return AmazonS3ClientBuilder.standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                    .withRegion(configuration.getRegion())
+                    .build();
+        }
+        return null;
+    }
+
+    @Provides
+    @Singleton
+    private AWSKMS getAmazonKms(
+            final AmazonS3 amazonS3,
+            final AWSCredentials credentials,
+            final Configuration configuration) {
+        if (configuration.isEnabled()) {
+            return AWSKMSClientBuilder.standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                    .withRegion(configuration.getRegion())
+                    .build();
+        }
+        return null;
     }
 
     @Provides
     @Singleton
     @Named("SourceQueueUrl")
-    private Optional<String> getQueueUrl(
-    final Optional<AmazonSQS> amazonSqs,
-    final Optional<Configuration> configuration) {
-
-        return amazonSqs.map(sqs -> sqs.getQueueUrl(configuration.get().getSourceQueueName()).getQueueUrl());
+    private String getQueueUrl(
+            final AmazonSQS amazonSqs,
+            final Configuration configuration) {
+        if (configuration.isEnabled()) {
+            return amazonSqs.getQueueUrl(configuration.getSourceQueueName()).getQueueUrl();
+        }
+        return null;
     }
 
     @Provides
     @Singleton
     private SqsClient getAmazonSqsClient(
-    final Optional<AmazonSQS> amazonSqs,
-    final @Named("SourceQueueUrl") Optional<String> sourceQueueUrl) {
-
-        if (amazonSqs.isPresent() && sourceQueueUrl.isPresent()){
-            return new AmazonSqsClient(amazonSqs.get(), sourceQueueUrl.get());
+            final AmazonSQS amazonSqs,
+            final @Named("SourceQueueUrl") String sourceQueueUrl,
+            final Configuration configuration) {
+        if (configuration.isEnabled()) {
+            return new AmazonSqsClient(amazonSqs, sourceQueueUrl);
         }
         return new StubSqsClient();
     }
 
     @Provides
     @Singleton
-    private Optional<AmazonS3> getAmazonS3(
-        final Optional<Configuration> configuration,
-        final Optional<AWSCredentials> credentials) {
-
-        return configuration.map(
-            config -> {
-                if (config.getBucketName() != null && config.getKeyName() != null) {
-                    if (hasAmazonCredentialWithARegion(credentials, configuration)) {
-                        return AmazonS3ClientBuilder.standard()
-                                                    .withCredentials(new AWSStaticCredentialsProvider(credentials.get()))
-                                                    .withRegion(config.getRegion())
-                                                    .build();
-                    }
-                    AmazonS3ClientBuilder.defaultClient();
-                }
-                return null;
-            });
-    }
-
-    @Provides
-    @Singleton
-    private Optional<AWSKMS> getAmazonKms(
-        final Optional<AmazonS3> amazonS3,
-        final Optional<AWSCredentials> credentials,
-        final Optional<Configuration> configuration) {
-
-        return amazonS3.map(s3 -> {
-            if (hasAmazonCredentialWithARegion(credentials, configuration)) {
-                return AWSKMSClientBuilder.standard()
-                                          .withCredentials(new AWSStaticCredentialsProvider(credentials.get()))
-                                          .withRegion(configuration.get().getRegion())
-                                          .build();
-            }
-            return AWSKMSClientBuilder.defaultClient();
-        });
-    }
-
-    @Provides
-    @Singleton
     private Encrypter getEncrypter(
-        final Optional<AmazonS3> amazonS3,
-        final Optional<Configuration> configuration,
-        final ObjectMapper mapper,
-        final Optional<AWSKMS> amazonKms) {
-
-        if (amazonS3.isPresent() && amazonKms.isPresent()) {
+            final AmazonS3 amazonS3,
+            final Configuration configuration,
+            final ObjectMapper mapper,
+            final AWSKMS amazonKms) {
+        if (configuration.isEnabled()) {
             try {
-                S3Object s3Object = amazonS3.get().getObject(configuration.get().getBucketName(), configuration.get().getKeyName());
+                S3Object s3Object = amazonS3.getObject(configuration.getBucketName(), configuration.getKeyName());
                 try (S3ObjectInputStream s3ObjectInputStream = s3Object.getObjectContent()) {
                     DecryptRequest request = new DecryptRequest().withCiphertextBlob(ByteBuffer.wrap(Base64.decode(IOUtils.toString(s3ObjectInputStream))));
-                    DecryptResult key = amazonKms.get().decrypt(request);
+                    DecryptResult key = amazonKms.decrypt(request);
 
                     return new EventEncrypter(key.getPlaintext().array(), mapper);
                 }
             } catch (SdkClientException e) {
                 System.err.println(
-                    String.format("Failed to load S3 bucket %s.", configuration.get().getBucketName()));
-            }
-            catch (IOException e) {
+                        String.format("Failed to load S3 bucket %s.", configuration.getBucketName()));
+            } catch (IOException e) {
                 System.err.println(
-                    String.format("Failed to read data from %s in %s.", configuration.get().getKeyName(), configuration.get().getBucketName()));
+                        String.format("Failed to read data from %s in %s.", configuration.getKeyName(), configuration.getBucketName()));
             }
         }
         return new StubEncrypter();
@@ -157,16 +136,8 @@ public class EventEmitterModule extends AbstractModule {
     @Provides
     @Singleton
     private EventEmitter getEventEmitter(
-        final SqsClient sqsClient,
-        final Encrypter encrypter) {
-
+            final SqsClient sqsClient,
+            final Encrypter encrypter) {
         return new EventEmitter(encrypter, sqsClient);
-    }
-
-    private boolean hasAmazonCredentialWithARegion(
-        final Optional<AWSCredentials> credentials,
-        final Optional<Configuration> configuration) {
-
-        return credentials.isPresent() && configuration.isPresent() && configuration.get().getRegion() != null;
     }
 }

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterBaseConfiguration.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterBaseConfiguration.java
@@ -1,0 +1,23 @@
+package uk.gov.ida.eventemitter;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.google.inject.Injector;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+public class EventEmitterBaseConfiguration {
+    protected static final String ACCESS_KEY_ID = "accessKeyId";
+    protected static final String ACCESS_SECRET_KEY = "accessSecretKey";
+    protected static final String KEY = "aesEncryptionKey";
+    protected static final String SOURCE_QUEUE_NAME = "sourceQueueName";
+    protected static final String BUCKET_NAME = "bucket.name";
+    protected static final String KEY_NAME = "keyName";
+    protected static Injector injector;
+    protected static String queueUrl;
+    protected static AmazonSQS sqs;
+    protected static AmazonS3 s3;
+    protected static ByteArrayOutputStream errorContent;
+    protected static PrintStream printStream;
+}

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -5,13 +5,10 @@ import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.model.DecryptRequest;
 import com.amazonaws.services.kms.model.DecryptResult;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.Message;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
-import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import com.google.inject.util.Modules;
@@ -26,7 +23,6 @@ import uk.gov.ida.eventemitter.utils.TestEvent;
 import uk.gov.ida.eventemitter.utils.TestEventEmitterModule;
 
 import java.nio.ByteBuffer;
-import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Matchers.any;
@@ -35,18 +31,8 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ida.eventemitter.utils.TestEventBuilder.aTestEventMessage;
 
 @RunWith(LocalstackTestRunner.class)
-public class EventEmitterIntegrationTest {
-
-    private static final String ACCESS_KEY_ID = "accessKeyId";
-    private static final String ACCESS_SECRET_KEY = "accessSecretKey";
-    private static final String KEY = "aesEncryptionKey";
-    private static final String SOURCE_QUEUE_NAME = "sourceQueueName";
-    private static final String BUCKET_NAME = "bucket.name";
-    private static final String KEY_NAME = "keyName";
-    private static Injector injector;
-    private static String queueUrl;
-    private static AmazonSQS sqs;
-    private static AmazonS3 s3;
+public class EventEmitterIntegrationTest extends EventEmitterBaseConfiguration {
+    private static final boolean CONFIGURATION_ENABLED = true;
 
     @BeforeClass
     public static void setUp() {
@@ -61,7 +47,14 @@ public class EventEmitterIntegrationTest {
             @Provides
             @Singleton
             private Configuration getConfiguration() {
-                return new TestConfiguration(ACCESS_KEY_ID, ACCESS_SECRET_KEY, Regions.EU_WEST_2, SOURCE_QUEUE_NAME, BUCKET_NAME, KEY_NAME);
+                return new TestConfiguration(
+                    CONFIGURATION_ENABLED,
+                    ACCESS_KEY_ID,
+                    ACCESS_SECRET_KEY,
+                    Regions.EU_WEST_2,
+                    SOURCE_QUEUE_NAME,
+                    BUCKET_NAME,
+                    KEY_NAME);
             }
         }, Modules.override(new EventEmitterModule()).with(new TestEventEmitterModule(awsKms)));
 

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithAMissingS3BucketIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithAMissingS3BucketIntegrationTest.java
@@ -5,17 +5,16 @@ import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.model.DecryptRequest;
 import com.amazonaws.services.kms.model.DecryptResult;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.model.Message;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
-import com.google.inject.Injector;
 import com.google.inject.Provides;
+import com.google.inject.ProvisionException;
 import com.google.inject.util.Modules;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import uk.gov.ida.eventemitter.utils.AmazonHelper;
 import uk.gov.ida.eventemitter.utils.TestConfiguration;
@@ -25,29 +24,17 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.nio.ByteBuffer;
-import java.util.Optional;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static uk.gov.ida.eventemitter.utils.TestEventBuilder.aTestEventMessage;
 
 @RunWith(LocalstackTestRunner.class)
-public class EventEmitterWithAMissingS3BucketIntegrationTest {
+public class EventEmitterWithAMissingS3BucketIntegrationTest extends EventEmitterBaseConfiguration {
+    private static final boolean CONFIGURATION_ENABLED = true;
 
-    private static final String ACCESS_KEY_ID = "accessKeyId";
-    private static final String ACCESS_SECRET_KEY = "accessSecretKey";
-    private static final String KEY = "aesEncryptionKey";
-    private static final String SOURCE_QUEUE_NAME = "sourceQueueName";
-    private static final String BUCKET_NAME = "bucket.name";
-    private static final String KEY_NAME = "keyName";
-    private static Injector injector;
-    private static String queueUrl;
-    private static AmazonSQS sqs;
-    private static AmazonS3 s3;
-    private static ByteArrayOutputStream errorContent;
-    private static PrintStream printStream;
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
 
     @BeforeClass
     public static void setUp() {
@@ -64,7 +51,15 @@ public class EventEmitterWithAMissingS3BucketIntegrationTest {
 
             @Provides
             private Configuration getConfiguration() {
-                return new TestConfiguration(ACCESS_KEY_ID, ACCESS_SECRET_KEY, Regions.EU_WEST_2, SOURCE_QUEUE_NAME, BUCKET_NAME, KEY_NAME);
+                return new TestConfiguration(
+                    CONFIGURATION_ENABLED,
+                    ACCESS_KEY_ID,
+                    ACCESS_SECRET_KEY,
+                    Regions.EU_WEST_2,
+                    SOURCE_QUEUE_NAME,
+                    BUCKET_NAME,
+                    KEY_NAME
+                );
             }
         }, Modules.override(new EventEmitterModule()).with(new TestEventEmitterModule(awsKms)));
 
@@ -81,23 +76,15 @@ public class EventEmitterWithAMissingS3BucketIntegrationTest {
         AmazonHelper.deleteBucket(s3, BUCKET_NAME);
         try {
             printStream.close();
-        }
-        finally {
+        } finally {
             errorContent.close();
         }
     }
 
     @Test
-    public void shouldEncryptMessageUsingStubEncrypterAndSendToSQSWhenS3BucketIsMissing() throws Exception {
-        final EventEmitter eventEmitter = injector.getInstance(EventEmitter.class);
-        final Event event = aTestEventMessage().build();
-
-        eventEmitter.record(event);
-
-        final Message message = AmazonHelper.getAMessageFromSqs(sqs, queueUrl);
-        sqs.deleteMessage(queueUrl, message.getReceiptHandle());
-
-        assertThat(errorContent.toString()).contains("Failed to load S3 bucket bucket.name.");
-        assertThat(message.getBody()).isEqualTo(String.format("Encrypted Event Id %s", event.getEventId().toString()));
+    public void shouldThrowExceptionWhenS3BucketIsMissing() {
+        expectedException.expect(ProvisionException.class);
+        expectedException.expectMessage("Failed to load S3 bucket bucket.name.");
+        injector.getInstance(EventEmitter.class);
     }
 }

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithDisabledConfigTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithDisabledConfigTest.java
@@ -1,0 +1,62 @@
+package uk.gov.ida.eventemitter;
+
+import cloud.localstack.LocalstackTestRunner;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kms.AWSKMS;
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Provides;
+import com.google.inject.util.Modules;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import uk.gov.ida.eventemitter.utils.TestConfiguration;
+import uk.gov.ida.eventemitter.utils.TestEvent;
+import uk.gov.ida.eventemitter.utils.TestEventEmitterModule;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.Mockito.mock;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@RunWith(LocalstackTestRunner.class)
+public class EventEmitterWithDisabledConfigTest extends EventEmitterBaseConfiguration {
+    private static final boolean CONFIGURATION_ENABLED = false;
+
+    @BeforeClass
+    public static void setUp() {
+        AWSKMS awsKms = mock(AWSKMS.class);
+        injector = Guice.createInjector(new AbstractModule() {
+            @Override
+            protected void configure() {}
+
+            @Provides
+            private Configuration getConfiguration() {
+                return new TestConfiguration(
+                    CONFIGURATION_ENABLED,
+                    ACCESS_KEY_ID,
+                    ACCESS_SECRET_KEY,
+                    Regions.EU_WEST_2,
+                    SOURCE_QUEUE_NAME,
+                    BUCKET_NAME,
+                    KEY_NAME
+                );
+            }
+        }, Modules.override(new EventEmitterModule()).with(new TestEventEmitterModule(awsKms)));
+    }
+
+    @Test
+    public void shouldReturnStubbedClientWhenConfigIsDisabled() {
+        final EventEmitter eventEmitter = injector.getInstance(EventEmitter.class);
+        final Map<String, String> details = new HashMap<>();
+        final Event event = new TestEvent(UUID.randomUUID(), DateTime.now(DateTimeZone.UTC), "eventType", details);
+
+        eventEmitter.record(event);
+
+        assertThat(eventEmitter.getClass().equals(StubSqsClient.class));
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/utils/AmazonHelper.java
+++ b/src/test/java/uk/gov/ida/eventemitter/utils/AmazonHelper.java
@@ -82,18 +82,18 @@ public class AmazonHelper {
         }
     }
 
-    public static Optional<String> getQueueUrl(final Injector injector) {
-        return (Optional<String>) injector.getInstance(
-            Key.get(TypeLiteral.get(Types.newParameterizedType(Optional.class, String.class)), Names.named("SourceQueueUrl")));
+    public static String getQueueUrl(final Injector injector) {
+        return (String) injector.getInstance(
+            Key.get(TypeLiteral.get(String.class), Names.named("SourceQueueUrl")));
     }
 
-    public static Optional<AmazonSQS> getInstanceOfAmazonSqs(final Injector injector) {
-        return (Optional<AmazonSQS>) injector.getInstance(
-            Key.get(TypeLiteral.get(Types.newParameterizedType(Optional.class, AmazonSQS.class))));
+    public static AmazonSQS getInstanceOfAmazonSqs(final Injector injector) {
+        return (AmazonSQS) injector.getInstance(
+                Key.get(TypeLiteral.get(AmazonSQS.class)));
     }
 
-    public static Optional<AmazonS3> getInstanceOfAmazonS3(final Injector injector) {
-        return (Optional<AmazonS3>) injector.getInstance(
-            Key.get(TypeLiteral.get(Types.newParameterizedType(Optional.class, AmazonS3.class))));
+    public static AmazonS3 getInstanceOfAmazonS3(final Injector injector) {
+        return (AmazonS3) injector.getInstance(
+            Key.get(TypeLiteral.get(AmazonS3.class)));
     }
 }

--- a/src/test/java/uk/gov/ida/eventemitter/utils/TestConfiguration.java
+++ b/src/test/java/uk/gov/ida/eventemitter/utils/TestConfiguration.java
@@ -29,6 +29,9 @@ public final class TestConfiguration implements Configuration {
     }
 
     @Override
+    public boolean isEnabled() { return true; }
+
+    @Override
     public String getAccessKeyId() {
         return accessKeyId;
     }

--- a/src/test/java/uk/gov/ida/eventemitter/utils/TestConfiguration.java
+++ b/src/test/java/uk/gov/ida/eventemitter/utils/TestConfiguration.java
@@ -5,6 +5,7 @@ import uk.gov.ida.eventemitter.Configuration;
 
 public final class TestConfiguration implements Configuration {
 
+    private final boolean enabled;
     private final String accessKeyId;
     private final String accessSecretKey;
     private final Regions region;
@@ -13,6 +14,7 @@ public final class TestConfiguration implements Configuration {
     private final String keyName;
 
     public TestConfiguration(
+        final boolean enabled,
         final String accessKeyId,
         final String accessSecretKey,
         final Regions region,
@@ -20,6 +22,7 @@ public final class TestConfiguration implements Configuration {
         final String bucketName,
         final String keyName) {
 
+        this.enabled = enabled;
         this.accessKeyId = accessKeyId;
         this.accessSecretKey = accessSecretKey;
         this.region = region;
@@ -29,7 +32,7 @@ public final class TestConfiguration implements Configuration {
     }
 
     @Override
-    public boolean isEnabled() { return true; }
+    public boolean isEnabled() { return enabled; }
 
     @Override
     public String getAccessKeyId() {

--- a/src/test/java/uk/gov/ida/eventemitter/utils/TestEventEmitterModule.java
+++ b/src/test/java/uk/gov/ida/eventemitter/utils/TestEventEmitterModule.java
@@ -11,8 +11,6 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import uk.gov.ida.eventemitter.Configuration;
 
-import java.util.Optional;
-
 public class TestEventEmitterModule extends AbstractModule {
 
     private final AWSKMS awsKms;
@@ -26,28 +24,28 @@ public class TestEventEmitterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private Optional<AmazonSQS> getAmazonSqs(final Optional<Configuration> configuration) {
-        if (configuration.isPresent() && configuration.get().getSourceQueueName() != null) {
-            return Optional.ofNullable(TestUtils.getClientSQS());
+    private AmazonSQS getAmazonSqs(final Configuration configuration) {
+        if (configuration.isEnabled() && configuration.getSourceQueueName() != null) {
+            return TestUtils.getClientSQS();
         }
-        return Optional.empty();
+        return null;
     }
 
     @Provides
     @Singleton
-    private Optional<AmazonS3> getAmazonS3(final Optional<Configuration> configuration) {
-        if (configuration.isPresent() &&
-            configuration.get().getBucketName() != null &&
-            configuration.get().getKeyName() != null) {
-            return Optional.ofNullable(TestUtils.getClientS3());
+    private AmazonS3 getAmazonS3(final Configuration configuration) {
+        if (configuration.isEnabled() &&
+            configuration.getBucketName() != null &&
+            configuration.getKeyName() != null) {
+            return TestUtils.getClientS3();
         }
-        return Optional.empty();
+        return null;
     }
 
     @Provides
     @Singleton
-    private Optional<AWSKMS> getAmazonKms(Optional<AmazonS3> amazonS3) {
-        return amazonS3.map(s3 -> awsKms);
+    private AWSKMS getAmazonKms(AmazonS3 amazonS3) {
+        return awsKms;
     }
 
     @Provides

--- a/src/test/java/uk/gov/ida/eventemitter/utils/TestEventEmitterModule.java
+++ b/src/test/java/uk/gov/ida/eventemitter/utils/TestEventEmitterModule.java
@@ -11,6 +11,8 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 import uk.gov.ida.eventemitter.Configuration;
 
+import javax.annotation.Nullable;
+
 public class TestEventEmitterModule extends AbstractModule {
 
     private final AWSKMS awsKms;
@@ -24,6 +26,7 @@ public class TestEventEmitterModule extends AbstractModule {
 
     @Provides
     @Singleton
+    @Nullable
     private AmazonSQS getAmazonSqs(final Configuration configuration) {
         if (configuration.isEnabled() && configuration.getSourceQueueName() != null) {
             return TestUtils.getClientSQS();
@@ -33,6 +36,7 @@ public class TestEventEmitterModule extends AbstractModule {
 
     @Provides
     @Singleton
+    @Nullable
     private AmazonS3 getAmazonS3(final Configuration configuration) {
         if (configuration.isEnabled() &&
             configuration.getBucketName() != null &&
@@ -44,7 +48,8 @@ public class TestEventEmitterModule extends AbstractModule {
 
     @Provides
     @Singleton
-    private AWSKMS getAmazonKms(AmazonS3 amazonS3) {
+    @Nullable
+    private AWSKMS getAmazonKms(@Nullable AmazonS3 amazonS3) {
         return awsKms;
     }
 


### PR DESCRIPTION
* Add new enabled flag to event emitter configuration.
* Can rely on flag rather than absence or presence of relevant config.
* Makes usage explicit and clear.
* Removed use of Optionals in favour of enabled flag.

Co-authored-by: Andy Paine <andy.paine@digital.cabinet-office.gov.uk>
Co-authored-by: dbes-gds <daniel.besbrode@digital.cabinet-office.gov.uk>

https://trello.com/c/8Xm7DiDy/29-deploy-current-mvp-components-in-joint-test-environment