### PR TITLE
Improve test with disabled config

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -46,7 +46,7 @@ public class EventEmitterModule extends AbstractModule {
     @Nullable
     private AmazonSQS getAmazonSqs(
             final Configuration configuration,
-            final AWSCredentials credentials) {
+            @Nullable final AWSCredentials credentials) {
         if (configuration.isEnabled()) {
             return AmazonSQSClientBuilder.standard()
                     .withCredentials(new AWSStaticCredentialsProvider(credentials))
@@ -61,7 +61,7 @@ public class EventEmitterModule extends AbstractModule {
     @Nullable
     private AmazonS3 getAmazonS3(
             final Configuration configuration,
-            final AWSCredentials credentials) {
+            @Nullable final AWSCredentials credentials) {
         if (configuration.isEnabled()) {
             return AmazonS3ClientBuilder.standard()
                     .withCredentials(new AWSStaticCredentialsProvider(credentials))
@@ -76,7 +76,7 @@ public class EventEmitterModule extends AbstractModule {
     @Nullable
     private AWSKMS getAmazonKms(
             @Nullable final AmazonS3 amazonS3,
-            final AWSCredentials credentials,
+            @Nullable final AWSCredentials credentials,
             final Configuration configuration) {
         if (configuration.isEnabled()) {
             return AWSKMSClientBuilder.standard()
@@ -118,7 +118,7 @@ public class EventEmitterModule extends AbstractModule {
             @Nullable final AmazonS3 amazonS3,
             final Configuration configuration,
             final ObjectMapper mapper,
-            final AWSKMS amazonKms) {
+            @Nullable final AWSKMS amazonKms) {
         if (configuration.isEnabled()) {
             try {
                 S3Object s3Object = amazonS3.getObject(configuration.getBucketName(), configuration.getKeyName());

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithDisabledConfigTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithDisabledConfigTest.java
@@ -1,12 +1,9 @@
 package uk.gov.ida.eventemitter;
 
 import cloud.localstack.LocalstackTestRunner;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.kms.AWSKMS;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Provides;
-import com.google.inject.util.Modules;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.BeforeClass;
@@ -14,13 +11,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import uk.gov.ida.eventemitter.utils.TestConfiguration;
 import uk.gov.ida.eventemitter.utils.TestEvent;
-import uk.gov.ida.eventemitter.utils.TestEventEmitterModule;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import static org.mockito.Mockito.mock;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 @RunWith(LocalstackTestRunner.class)
@@ -29,7 +24,6 @@ public class EventEmitterWithDisabledConfigTest extends EventEmitterBaseConfigur
 
     @BeforeClass
     public static void setUp() {
-        AWSKMS awsKms = mock(AWSKMS.class);
         injector = Guice.createInjector(new AbstractModule() {
             @Override
             protected void configure() {}
@@ -38,15 +32,15 @@ public class EventEmitterWithDisabledConfigTest extends EventEmitterBaseConfigur
             private Configuration getConfiguration() {
                 return new TestConfiguration(
                     CONFIGURATION_ENABLED,
-                    ACCESS_KEY_ID,
-                    ACCESS_SECRET_KEY,
-                    Regions.EU_WEST_2,
-                    SOURCE_QUEUE_NAME,
-                    BUCKET_NAME,
-                    KEY_NAME
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
                 );
             }
-        }, Modules.override(new EventEmitterModule()).with(new TestEventEmitterModule(awsKms)));
+        }, new EventEmitterModule());
     }
 
     @Test


### PR DESCRIPTION
Updated test to test the actual config rather than the test config. This also meant passing in null parameters which is what would happen if the config is disabled.

https://trello.com/c/8Xm7DiDy/29-deploy-current-mvp-components-in-joint-test-environment

Co-authored-by: Daniel Besbrode
<daniel.besbrode@digital.cabinet-office.gov.uk>