### PR TITLE
ZD-8Xm7DiDy: Add SQS queue account ID

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/Configuration.java
+++ b/src/main/java/uk/gov/ida/eventemitter/Configuration.java
@@ -16,4 +16,6 @@ public interface Configuration {
     String getBucketName();
 
     String getKeyName();
+
+    String getQueueAccountId();
 }

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -14,6 +14,7 @@ import com.amazonaws.services.s3.model.S3Object;
 import com.amazonaws.services.s3.model.S3ObjectInputStream;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.amazonaws.util.Base64;
 import com.amazonaws.util.IOUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -95,7 +96,9 @@ public class EventEmitterModule extends AbstractModule {
             @Nullable final AmazonSQS amazonSqs,
             final Configuration configuration) {
         if (configuration.isEnabled()) {
-            return amazonSqs.getQueueUrl(configuration.getSourceQueueName()).getQueueUrl();
+            GetQueueUrlRequest queueUrlRequest = new GetQueueUrlRequest(configuration.getSourceQueueName())
+                    .withQueueOwnerAWSAccountId(configuration.getQueueAccountId());
+            return amazonSqs.getQueueUrl(queueUrlRequest).getQueueUrl();
         }
         return null;
     }

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterBaseConfiguration.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterBaseConfiguration.java
@@ -11,6 +11,7 @@ public class EventEmitterBaseConfiguration {
     protected static final String ACCESS_KEY_ID = "accessKeyId";
     protected static final String ACCESS_SECRET_KEY = "accessSecretKey";
     protected static final String KEY = "aesEncryptionKey";
+    protected static final String QUEUE_ACCOUNT_ID = "queueAccountId";
     protected static final String SOURCE_QUEUE_NAME = "sourceQueueName";
     protected static final String BUCKET_NAME = "bucket.name";
     protected static final String KEY_NAME = "keyName";

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -52,6 +52,7 @@ public class EventEmitterIntegrationTest extends EventEmitterBaseConfiguration {
                     ACCESS_KEY_ID,
                     ACCESS_SECRET_KEY,
                     Regions.EU_WEST_2,
+                    QUEUE_ACCOUNT_ID,
                     SOURCE_QUEUE_NAME,
                     BUCKET_NAME,
                     KEY_NAME);

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithAMissingS3BucketIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithAMissingS3BucketIntegrationTest.java
@@ -56,6 +56,7 @@ public class EventEmitterWithAMissingS3BucketIntegrationTest extends EventEmitte
                     ACCESS_KEY_ID,
                     ACCESS_SECRET_KEY,
                     Regions.EU_WEST_2,
+                    QUEUE_ACCOUNT_ID,
                     SOURCE_QUEUE_NAME,
                     BUCKET_NAME,
                     KEY_NAME

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithDisabledConfigTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithDisabledConfigTest.java
@@ -37,6 +37,7 @@ public class EventEmitterWithDisabledConfigTest extends EventEmitterBaseConfigur
                     null,
                     null,
                     null,
+                    null,
                     null
                 );
             }

--- a/src/test/java/uk/gov/ida/eventemitter/utils/TestConfiguration.java
+++ b/src/test/java/uk/gov/ida/eventemitter/utils/TestConfiguration.java
@@ -9,6 +9,7 @@ public final class TestConfiguration implements Configuration {
     private final String accessKeyId;
     private final String accessSecretKey;
     private final Regions region;
+    private final String queueAccountId;
     private final String sourceQueueName;
     private final String bucketName;
     private final String keyName;
@@ -18,6 +19,7 @@ public final class TestConfiguration implements Configuration {
         final String accessKeyId,
         final String accessSecretKey,
         final Regions region,
+        final String queueAccountId,
         final String sourceQueueName,
         final String bucketName,
         final String keyName) {
@@ -26,6 +28,7 @@ public final class TestConfiguration implements Configuration {
         this.accessKeyId = accessKeyId;
         this.accessSecretKey = accessSecretKey;
         this.region = region;
+        this.queueAccountId = queueAccountId;
         this.sourceQueueName = sourceQueueName;
         this.bucketName = bucketName;
         this.keyName = keyName;
@@ -62,5 +65,10 @@ public final class TestConfiguration implements Configuration {
     @Override
     public String getKeyName() {
         return keyName;
+    }
+
+    @Override
+    public String getQueueAccountId() {
+        return queueAccountId;
     }
 }


### PR DESCRIPTION
- It seems that when looking up a queue, the account ID of
the account that the application is running in is used
- In joint/other hub envs, we will need to explicitly specify that
the queue is in a different account