### PR TITLE
TRELLO-8Xm7DiDy: Make exceptions more explicit

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterConfigurationException.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterConfigurationException.java
@@ -1,7 +1,9 @@
 package uk.gov.ida.eventemitter;
 
+import static java.lang.String.format;
+
 public class EventEmitterConfigurationException extends RuntimeException {
-    public EventEmitterConfigurationException(String message) {
-        super(message);
+    public EventEmitterConfigurationException(String message, Exception e) {
+        super(format("%s: %s", message, e.getMessage()));
     }
 }

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -131,13 +131,15 @@ public class EventEmitterModule extends AbstractModule {
 
                     return new EventEncrypter(key.getPlaintext().array(), mapper);
                 }
-            } catch (SdkClientException e) {
+            } catch (SdkClientException exception) {
                 throw new EventEmitterConfigurationException(
-                    String.format("Failed to load S3 bucket %s.", configuration.getBucketName())
+                    String.format("Failed to load S3 bucket %s", configuration.getBucketName()),
+                    exception
                 );
-            } catch (IOException e) {
+            } catch (IOException exception) {
                 throw new EventEmitterConfigurationException(
-                    String.format("Failed to read data from %s in %s.", configuration.getKeyName(), configuration.getBucketName())
+                    String.format("Failed to read data from %s in %s", configuration.getKeyName(), configuration.getBucketName()),
+                    exception
                 );
             }
         }


### PR DESCRIPTION
- We are trying to debug errors in joint and realised that
out exception wrapping was swallowing a lot of the details
about what went wrong
- Make the underlying exception a constructor parameter for
the wrapped exception to make it clear that when using the
EventEmitterConfigurationException, you should pass the original
exception