### PR TITLE
Change timestamp serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ dependencies {
     testCompile 'junit:junit:4.12',
                 'org.assertj:assertj-core:3.9.0',
                 'org.mockito:mockito-core:1.9.5',
-                'cloud.localstack:localstack-utils:0.1.14'
+                'cloud.localstack:localstack-utils:0.1.14',
+                'org.json:json:20180130'
 }
 
 allprojects {

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -84,10 +84,9 @@ public class EventEmitterModule extends AbstractModule {
     @Singleton
     private Encrypter getEncrypter(
             final Configuration configuration,
-            final ObjectMapper mapper,
             final @Nullable @Named("EncryptionKey") byte[] encryptionKey) {
         if (configuration.isEnabled()) {
-            return new EventEncrypter(encryptionKey, mapper);
+            return new EventEncrypter(encryptionKey);
         }
         return new StubEncrypter();
     }

--- a/src/main/java/uk/gov/ida/eventemitter/EventEncrypter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEncrypter.java
@@ -1,6 +1,7 @@
 package uk.gov.ida.eventemitter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.inject.Inject;
 import org.apache.commons.codec.binary.Base64;
 
@@ -13,13 +14,11 @@ public class EventEncrypter implements Encrypter {
 
     public static final int INITIALISATION_VECTOR_SIZE = 16;
     private final byte[] key;
-    private final ObjectMapper mapper;
+    private final ObjectMapper mapper = new ObjectMapper().registerModule(new JodaModule());
 
     @Inject
-    public EventEncrypter(final byte[] key,
-                          final ObjectMapper mapper) {
+    public EventEncrypter(final byte[] key) {
         this.key = key;
-        this.mapper = mapper;
     }
 
     public String encrypt(final Event event) throws Exception {

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -2,9 +2,6 @@ package uk.gov.ida.eventemitter;
 
 import cloud.localstack.LocalstackTestRunner;
 import com.amazonaws.regions.Regions;
-import com.amazonaws.services.kms.AWSKMS;
-import com.amazonaws.services.kms.model.DecryptRequest;
-import com.amazonaws.services.kms.model.DecryptResult;
 import com.amazonaws.services.sqs.model.Message;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
@@ -22,12 +19,7 @@ import uk.gov.ida.eventemitter.utils.TestDecrypter;
 import uk.gov.ida.eventemitter.utils.TestEvent;
 import uk.gov.ida.eventemitter.utils.TestEventEmitterModule;
 
-import java.nio.ByteBuffer;
-
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static uk.gov.ida.eventemitter.utils.TestEventBuilder.aTestEventMessage;
 
 @RunWith(LocalstackTestRunner.class)

--- a/src/test/java/uk/gov/ida/eventemitter/utils/TestDecrypter.java
+++ b/src/test/java/uk/gov/ida/eventemitter/utils/TestDecrypter.java
@@ -22,13 +22,18 @@ public class TestDecrypter<T> {
         this.mapper = mapper;
     }
 
-    public T decrypt(final String bas64EncodedEncryptedEvent, final Class<T> klass) throws Exception {
+    public T decrypt(final String base64EncodedEncryptedEvent, final Class<T> klass) throws Exception {
+        final String event = decrypt(base64EncodedEncryptedEvent);
+        return (T) mapper.readValue(event, klass);
+    }
+
+    public String decrypt(final String bas64EncodedEncryptedEvent) throws Exception {
         final byte[] encryptedEventAndIv = Base64.decodeBase64(bas64EncodedEncryptedEvent);
         final byte[] initialisationVector = extractIv(encryptedEventAndIv);
         final byte[] encryptedEvent = extractEncryptedEvent(encryptedEventAndIv);
         final byte[] event = decryptEncryptedEvent(encryptedEvent, initialisationVector);
 
-        return (T) mapper.readValue(event, klass);
+        return new String(event);
     }
 
     private byte[] extractIv(final byte[] encryptedEventAndIv) {


### PR DESCRIPTION
The lambda was trying to parse the timestamp as an integer however was receiving a java datetime object. We now parse this to time since epoch in milliseconds.

https://trello.com/c/Qjjmp2cr/84-fix-any-joint-issues

Co-authored-by: Andy Paine <andy.paine@digital.cabinet-office.gov.uk>