### PR TITLE
TRELLO-W0VXgdcb: Change Event class back to interface

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/Event.java
+++ b/src/main/java/uk/gov/ida/eventemitter/Event.java
@@ -1,119 +1,21 @@
 package uk.gov.ida.eventemitter;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 
-import java.util.Map;
-import java.util.Objects;
+import java.util.EnumMap;
 import java.util.UUID;
 
-public final class Event {
+public interface Event {
 
-    @JsonProperty
-    private UUID eventId;
+    UUID getEventId();
 
-    @JsonProperty
-    private DateTime timestamp;
+    DateTime getTimestamp();
 
-    @JsonProperty
-    private String eventType;
+    String getEventType();
 
-    @JsonProperty
-    private String originatingService;
+    EnumMap<EventDetailsKey,String> getDetails();
 
-    @JsonProperty
-    private String sessionId;
+    String getOriginatingService();
 
-    @JsonProperty
-    private Map<EventDetailsKey, String> details;
-
-    private Event() {
-    }
-
-    public Event(final UUID eventId,
-                 final DateTime timestamp,
-                 final String eventType,
-                 final String originatingService,
-                 final String sessionId,
-                 final Map<EventDetailsKey, String> details) {
-        this.eventId = eventId;
-        this.timestamp = timestamp;
-        this.originatingService = originatingService;
-        this.sessionId = sessionId;
-        this.eventType = eventType;
-        this.details = details;
-    }
-
-    public Event(final String originatingService,
-                 final String sessionId,
-                 final String eventType,
-                 final Map<EventDetailsKey, String> details) {
-        this(
-            UUID.randomUUID(),
-            DateTime.now(DateTimeZone.UTC),
-            originatingService,
-            sessionId,
-            eventType,
-            details);
-    }
-
-    public UUID getEventId() {
-        return eventId;
-    }
-
-    public DateTime getTimestamp() {
-        return timestamp;
-    }
-
-    public String getEventType() {
-        return eventType;
-    }
-
-    public String getOriginatingService() {
-        return originatingService;
-    }
-
-    public String getSessionId() {
-        return sessionId;
-    }
-
-    public Map<EventDetailsKey, String> getDetails() {
-        return details;
-    }
-
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("Event{");
-        sb.append("eventId=").append(eventId);
-        sb.append(", timestamp=").append(timestamp);
-        sb.append(", eventType='").append(eventType).append('\'');
-        sb.append(", originatingService='").append(originatingService).append('\'');
-        sb.append(", sessionId='").append(sessionId).append('\'');
-        sb.append(", details=").append(details);
-        sb.append('}');
-        return sb.toString();
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        final Event event = (Event) o;
-        return Objects.equals(eventId, event.eventId) &&
-               Objects.equals(timestamp, event.timestamp) &&
-               Objects.equals(eventType, event.eventType) &&
-               Objects.equals(originatingService, event.originatingService) &&
-               Objects.equals(sessionId, event.sessionId) &&
-               Objects.equals(details, event.details);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(eventId, timestamp, eventType, originatingService, sessionId, details);
-    }
+    String getSessionId();
 }

--- a/src/main/java/uk/gov/ida/eventemitter/EventHasher.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventHasher.java
@@ -2,8 +2,7 @@ package uk.gov.ida.eventemitter;
 
 import com.google.inject.Inject;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.EnumMap;
 
 public class EventHasher {
 
@@ -17,14 +16,14 @@ public class EventHasher {
     }
 
     public Event replacePersistentIdWithHashedPersistentId(final Event event) {
-        final Map<EventDetailsKey, String> details = event.getDetails();
+        final EnumMap<EventDetailsKey, String> details = event.getDetails();
 
         if (details != null) {
             final String pid = details.get(EventDetailsKey.pid);
 
             if (pid != null) {
                 final String idpEntityId = details.get(EventDetailsKey.idp_entity_id);
-                final Map<EventDetailsKey, String> newDetails = new HashMap<>();
+                final EnumMap<EventDetailsKey, String> newDetails = new EnumMap<>(EventDetailsKey.class);
 
                 if (idpEntityId == null) {
                     newDetails.put(EventDetailsKey.pid, PID_REMOVED);
@@ -39,7 +38,7 @@ public class EventHasher {
                     }
                 }
 
-                return new Event(
+                return new EventMessage(
                     event.getEventId(),
                     event.getTimestamp(),
                     event.getEventType(),

--- a/src/main/java/uk/gov/ida/eventemitter/EventMessage.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventMessage.java
@@ -1,0 +1,125 @@
+package uk.gov.ida.eventemitter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.util.EnumMap;
+import java.util.Objects;
+import java.util.UUID;
+
+public final class EventMessage implements Event {
+
+    @JsonProperty
+    private UUID eventId;
+
+    @JsonProperty
+    private DateTime timestamp;
+
+    @JsonProperty
+    private String eventType;
+
+    @JsonProperty
+    private String originatingService;
+
+    @JsonProperty
+    private String sessionId;
+
+    @JsonProperty
+    private EnumMap<EventDetailsKey, String> details;
+
+    private EventMessage() {
+    }
+
+    public EventMessage(final UUID eventId,
+                 final DateTime timestamp,
+                 final String eventType,
+                 final String originatingService,
+                 final String sessionId,
+                 final EnumMap<EventDetailsKey, String> details) {
+        this.eventId = eventId;
+        this.timestamp = timestamp;
+        this.originatingService = originatingService;
+        this.sessionId = sessionId;
+        this.eventType = eventType;
+        this.details = details;
+    }
+
+    public EventMessage(final String originatingService,
+                 final String sessionId,
+                 final String eventType,
+                 final EnumMap<EventDetailsKey, String> details) {
+        this(
+            UUID.randomUUID(),
+            DateTime.now(DateTimeZone.UTC),
+            originatingService,
+            sessionId,
+            eventType,
+            details);
+    }
+
+    @Override
+    public UUID getEventId() {
+        return eventId;
+    }
+
+    @Override
+    public DateTime getTimestamp() {
+        return timestamp;
+    }
+
+    @Override
+    public String getEventType() {
+        return eventType;
+    }
+
+    @Override
+    public String getOriginatingService() {
+        return originatingService;
+    }
+
+    @Override
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    @Override
+    public EnumMap<EventDetailsKey, String> getDetails() {
+        return details;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Event{");
+        sb.append("eventId=").append(eventId);
+        sb.append(", timestamp=").append(timestamp);
+        sb.append(", eventType='").append(eventType).append('\'');
+        sb.append(", originatingService='").append(originatingService).append('\'');
+        sb.append(", sessionId='").append(sessionId).append('\'');
+        sb.append(", details=").append(details);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final EventMessage event = (EventMessage) o;
+        return Objects.equals(eventId, event.eventId) &&
+               Objects.equals(timestamp, event.timestamp) &&
+               Objects.equals(eventType, event.eventType) &&
+               Objects.equals(originatingService, event.originatingService) &&
+               Objects.equals(sessionId, event.sessionId) &&
+               Objects.equals(details, event.details);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId, timestamp, eventType, originatingService, sessionId, details);
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterAmazonEventSenderTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterAmazonEventSenderTest.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static uk.gov.ida.eventemitter.EventEmitterTestHelper.AUDIT_EVENTS_API_RESOURCE;
 import static uk.gov.ida.eventemitter.EventEmitterTestHelper.createTestResponseHeadersMap;
-import static uk.gov.ida.eventemitter.utils.EventBuilder.anEventMessage;
+import static uk.gov.ida.eventemitter.utils.EventMessageBuilder.anEventMessage;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventEmitterAmazonEventSenderTest {

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterIntegrationTest.java
@@ -31,7 +31,7 @@ import static uk.gov.ida.eventemitter.EventEmitterTestHelper.ACCESS_SECRET_KEY;
 import static uk.gov.ida.eventemitter.EventEmitterTestHelper.AUDIT_EVENTS_API_RESOURCE;
 import static uk.gov.ida.eventemitter.EventEmitterTestHelper.AUDIT_EVENTS_API_RESOURCE_INVALID;
 import static uk.gov.ida.eventemitter.EventEmitterTestHelper.KEY;
-import static uk.gov.ida.eventemitter.utils.EventBuilder.anEventMessage;
+import static uk.gov.ida.eventemitter.utils.EventMessageBuilder.anEventMessage;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventEmitterIntegrationTest {
@@ -91,8 +91,8 @@ public class EventEmitterIntegrationTest {
         eventEmitter.record(expectedEvent);
 
         final String message = new String(apiGatewayStub.getLastRequest().getEntityBytes());
-        final TestDecrypter<Event> decrypter = new TestDecrypter(KEY, injector.getInstance(ObjectMapper.class));
-        final Event actualEvent = decrypter.decrypt(message, Event.class);
+        final TestDecrypter<EventMessage> decrypter = new TestDecrypter(KEY, injector.getInstance(ObjectMapper.class));
+        final Event actualEvent = decrypter.decrypt(message, EventMessage.class);
         final Map<EventDetailsKey, String> expectedDetails = actualEvent.getDetails();
         final Map<EventDetailsKey, String> actualDetails = actualEvent.getDetails();
 

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterTest.java
@@ -14,7 +14,7 @@ import java.io.PrintStream;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.ida.eventemitter.utils.EventBuilder.anEventMessage;
+import static uk.gov.ida.eventemitter.utils.EventMessageBuilder.anEventMessage;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventEmitterTest {

--- a/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithDisabledConfigTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEmitterWithDisabledConfigTest.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static uk.gov.ida.eventemitter.utils.EventBuilder.anEventMessage;
+import static uk.gov.ida.eventemitter.utils.EventMessageBuilder.anEventMessage;
 
 
 public class EventEmitterWithDisabledConfigTest {

--- a/src/test/java/uk/gov/ida/eventemitter/EventEncrypterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventEncrypterTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import uk.gov.ida.eventemitter.utils.TestDecrypter;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static uk.gov.ida.eventemitter.utils.EventBuilder.anEventMessage;
+import static uk.gov.ida.eventemitter.utils.EventMessageBuilder.anEventMessage;
 
 public class EventEncrypterTest {
 
@@ -34,7 +34,7 @@ public class EventEncrypterTest {
     public void shouldEncryptEvent() throws Exception {
         final String encryptedEvent = eventEncrypter.encrypt(event);
         String decryptedEvent = decrypter.decrypt(encryptedEvent);
-        assertThat(mapper.readValue(decryptedEvent, Event.class)).isEqualTo(event);
+        assertThat(mapper.readValue(decryptedEvent, EventMessage.class)).isEqualTo(event);
 
         JSONObject jsonObject = new JSONObject(decryptedEvent);
         assertThat(jsonObject.getLong("timestamp")).isEqualTo(event.getTimestamp().getMillis());

--- a/src/test/java/uk/gov/ida/eventemitter/EventHasherTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/EventHasherTest.java
@@ -13,7 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static uk.gov.ida.eventemitter.utils.EventBuilder.anEventMessage;
+import static uk.gov.ida.eventemitter.utils.EventMessageBuilder.anEventMessage;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EventHasherTest {

--- a/src/test/java/uk/gov/ida/eventemitter/StubEncrypterTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/StubEncrypterTest.java
@@ -3,7 +3,7 @@ package uk.gov.ida.eventemitter;
 import org.junit.Test;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static uk.gov.ida.eventemitter.utils.EventBuilder.anEventMessage;
+import static uk.gov.ida.eventemitter.utils.EventMessageBuilder.anEventMessage;
 
 public class StubEncrypterTest {
 

--- a/src/test/java/uk/gov/ida/eventemitter/StubEventSenderTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/StubEventSenderTest.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static uk.gov.ida.eventemitter.utils.EventBuilder.anEventMessage;
+import static uk.gov.ida.eventemitter.utils.EventMessageBuilder.anEventMessage;
 
 public class StubEventSenderTest {
 
@@ -45,7 +45,7 @@ public class StubEventSenderTest {
 
     @Test
     public void shouldNotThrowErrorsIfInputsAreNull() throws IOException {
-        event = new Event(null, null, null, null, null, null);
+        event = new EventMessage(null, null, null, null, null, null);
 
         try (ByteArrayOutputStream outContent = new ByteArrayOutputStream();
              PrintStream printStream = new PrintStream(outContent)) {

--- a/src/test/java/uk/gov/ida/eventemitter/utils/EventMessageBuilder.java
+++ b/src/test/java/uk/gov/ida/eventemitter/utils/EventMessageBuilder.java
@@ -1,35 +1,34 @@
 package uk.gov.ida.eventemitter.utils;
 
-import uk.gov.ida.eventemitter.Event;
 import uk.gov.ida.eventemitter.EventDetailsKey;
+import uk.gov.ida.eventemitter.EventMessage;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.EnumMap;
 import java.util.UUID;
 
-public class EventBuilder {
+public class EventMessageBuilder {
 
     private String eventType = "error";
     private String originatingService = "originating service";
     private String sessionId = "session id";
-    private Map<EventDetailsKey, String> details = new HashMap<>();
+    private EnumMap<EventDetailsKey, String> details = new EnumMap<>(EventDetailsKey.class);
 
     {
         details.put(EventDetailsKey.message, "Session error");
         details.put(EventDetailsKey.error_id, UUID.randomUUID().toString());
     }
 
-    public static EventBuilder anEventMessage() {
-        return new EventBuilder();
+    public static EventMessageBuilder anEventMessage() {
+        return new EventMessageBuilder();
     }
 
-    public EventBuilder withDetailsField(final EventDetailsKey key, final String value) {
+    public EventMessageBuilder withDetailsField(final EventDetailsKey key, final String value) {
         details.put(key, value);
         return this;
     }
 
-    public Event build() {
-        return new Event(
+    public EventMessage build() {
+        return new EventMessage(
             originatingService,
             sessionId,
             eventType,


### PR DESCRIPTION
Rest-utils library and Verify Hub are passing in EventSinkHubEvent object to Event Emitter via Event interface. This commit is needed to avoid making code changes to existing code in Verify Hub and Rest Utils library apart from upgrading its dependency to use latest version of event emitter library.

Co-authored-by: adityapahuja <aditya.pahuja@digital.cabinet-office.gov.uk>
Co-authored-by: dbes-gds <daniel.besbrode@digital.cabinet-office.gov.uk>