### PR TITLE
Trello-JJU68z53: Add retry logic

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/AmazonEventSender.java
+++ b/src/main/java/uk/gov/ida/eventemitter/AmazonEventSender.java
@@ -38,7 +38,7 @@ public class AmazonEventSender implements EventSender {
         Request<Void> request = createRequest(encryptedEvent);
         request = signRequest(request);
 
-        Response<Void> response = new AmazonHttpClient(new ClientConfiguration().withMaxErrorRetry(0))
+        new AmazonHttpClient(new ClientConfiguration())
                 .requestExecutionBuilder()
                 .executionContext(new ExecutionContext(true))
                 .request(request)

--- a/src/main/java/uk/gov/ida/eventemitter/AwsResponseException.java
+++ b/src/main/java/uk/gov/ida/eventemitter/AwsResponseException.java
@@ -1,13 +1,15 @@
 package uk.gov.ida.eventemitter;
 
-import com.amazonaws.SdkBaseException;
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.http.HttpResponse;
 
-public class AwsResponseException extends SdkBaseException {
+public class AwsResponseException extends AmazonServiceException {
     private HttpResponse response;
 
     public AwsResponseException(HttpResponse response) {
         super(response.getStatusText());
+        this.setStatusCode(response.getStatusCode());
+        this.setServiceName("API Gateway");
         this.response = response;
     }
 


### PR DESCRIPTION
- The Amazon client has some built in default retry policies that we
  should probably use
- They have the concept of default "retryable" statuses (e.g. 5xx)
- Exception has changed due to a cast going on inside some library
  code - the status is also needed to decide if it is "retryable"