### PR TITLE
HUB-380: Add Piwik Session ID and Journey Type to events

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/EventDetailsKey.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventDetailsKey.java
@@ -22,5 +22,7 @@ public enum EventDetailsKey {
     principal_ip_address_as_seen_by_idp,
     principal_ip_address_as_seen_by_hub,
     request_id,
-    country_code
+    country_code,
+    analytics_session_id,
+    journey_type
 }


### PR DESCRIPTION
Updated EventDetailsKey enum to include new keys

Co-authored-by: Chris Clayson <chris.clayson@digital.cabinet-office.gov.uk>