### PR TITLE
BAU Bump dropwizard-logstash to 1.3.9-71

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
                 'com.google.code.findbugs:jsr305:1.3.9',
                 'com.amazonaws:aws-java-sdk-s3:1.11.277',
                 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.8.10',
-                'uk.gov.ida:dropwizard-logstash:1.3.5-70'
+                'uk.gov.ida:dropwizard-logstash:1.3.9-71'
 
     testCompile 'junit:junit:4.12',
                 'uk.gov.ida:common-test-utils:2.0.0-44',


### PR DESCRIPTION
This pulls in dropwizard-core 1.3.9 which fixes a number of security
vulnerabilities, namely:

[CVE-2018-19362](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72882)
[CVE-2018-19361](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72884)
[CVE-2018-14718](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72448)
[CVE-2018-19360](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72883)
[CVE-2018-14719](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72450)
[CVE-2018-14721](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72451)
[CVE-2018-14720](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-72449)
[CVE-2018-1000873](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATATYPE-173759)
[CVE-2018-12545](https://app.snyk.io/vuln/SNYK-JAVA-ORGECLIPSEJETTY-174011)
[CVE-2018-10237](https://app.snyk.io/vuln/SNYK-JAVA-COMGOOGLEGUAVA-32236)