### PR TITLE
Add encrypted event when logging errors

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitter.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitter.java
@@ -36,10 +36,9 @@ public class EventEmitter {
                 eventSender.sendAuthenticated(hashedEvent, encryptedEvent);
                 LOG.info(String.format("Sent Event Message [Event Id: %s]", event.getEventId()));
             } catch (AwsResponseException awsEx) {
-                LOG.error(String.format("Failed to send a message [Event Id: %s] to the api gateway. Status: %s Error Message: %s", event.getEventId(), awsEx.getResponse().getStatusCode(), awsEx.getMessage()));
+                LOG.error(String.format("Failed to send a message [Event Id: %s] to the api gateway. Status: %s Error Message: %s Event Detail: %s", event.getEventId(), awsEx.getResponse().getStatusCode(), awsEx.getMessage(), encryptedEvent));
             } catch (Exception ex) {
-                LOG.error(String.format("Failed to send a message [Event Id: %s] to the api gateway. Error Message: %s", event.getEventId(), ex.getMessage()));
-                LOG.error(String.format("Event Message: %s", event));
+                LOG.error(String.format("Failed to send a message [Event Id: %s] to the api gateway. Error Message: %s Event Detail: %s", event.getEventId(), ex.getMessage(), encryptedEvent));
             }
         } else {
             LOG.error("Unable to send a message due to event containing null value.");


### PR DESCRIPTION
As the Event Sink MongoDB no longer exists, the only way we will be able to replay messages which failed to send is by capturing them in Kibana.  This is intended to be a stop-gap solution; in the long run we think it would be preferable for user journeys to fail if the audit logger is unavailable.

https://trello.com/c/y8ieTzSO/14-needs-kick-off-adjust-event-emitter-to-log-encrypted-event


In an ideal world, making this change would entail altering/adding tests.  Unfortunately, it is pretty fiddly to check these log messages in much detail - with the addition of the encrypted event, there are now two sections of the log strings which are awkward to check in the tests (the error message, and now additionally the encrypted event).  Prior to this PR, the approach was simply to only check the log string up to the static label of the original awkward section ("Error Message:"), but not check the awkward value.  Now, the first awkward value lies ahead of the static label of the new awkward section ("Event Detail:), so it's fiddly to even check that the new label is there, let alone checking the value.

I can see various possible approaches:

1) In each test, put in an additional assertion which checks that the new static label ("Event Detail:") is present, but doesn't look for the rest of the expected string.  I think this assertion would be of very limited value.

2) Do a regex match instead of a substring match.  This would let us check the structure of log string pretty effectively, but would also be seriously ugly, to the point that the tests would be pretty hard to interpret.

3) Hard code the first awkward value, the error message, in full in the test expectations.  Again, I don't think it's worth the extra noise and brittleness.

4) Use a mock encrypter so that we can control its output, and follow one of the above approaches to check that we actually get the expected encrypted event string in the log message.  This would be great and would make the above approaches more worthwhile, but it doesn't look to me like we've got the flexibility to use a mock encrypter, and I don't know how to refactor the tests to inject one.  So, I've followed a fifth approach...

5) Don't bother.  This approach arguably follows the existing spirit of the tests.