### PR TITLE
BAU Upgrade dropwizard-logstash to 1.3.12-72

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ dependencies {
                 'com.google.code.findbugs:jsr305:1.3.9',
                 'com.amazonaws:aws-java-sdk-s3:1.11.277',
                 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.8.10',
-                'uk.gov.ida:dropwizard-logstash:1.3.9-71'
+                'uk.gov.ida:dropwizard-logstash:1.3.12-72'
 
     testCompile 'junit:junit:4.12',
                 'uk.gov.ida:common-test-utils:2.0.0-44',


### PR DESCRIPTION
It uses 1.3.12 of dropwizard rather than 1.3.9 which was susceptible to
a couple of CSVs.