### PR TITLE
OGD-152: Run Tests in Event Emitter Jenkins Build

### DIFF
--- a/build.jenkins
+++ b/build.jenkins
@@ -6,7 +6,7 @@ pipeline {
       agent {
         dockerfile { additionalBuildArgs "--pull" }
       }
-      steps { sh './gradlew build' }
+      steps { sh './gradlew clean build integrationTest' }
     }
     stage('Publish') {
       agent {


### PR DESCRIPTION
- Tests are not currently running.
- Update build command to run unit and integration tests.

Co-authored-by: Alex Wilson <alex.wilson@digital.cabinet-office.gov.uk>