### PR TITLE
OGD-138: Refactor Event Emitter SQS Module

### DIFF
--- a/src/intTest/java/uk/gov/ida/eventemitter/sqs/EventEmitterSQSIntegrationTest.java
+++ b/src/intTest/java/uk/gov/ida/eventemitter/sqs/EventEmitterSQSIntegrationTest.java
@@ -3,6 +3,7 @@ package uk.gov.ida.eventemitter.sqs;
 import com.amazonaws.regions.Regions;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Injector;
+import com.google.inject.Stage;
 import org.joda.time.DateTime;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -30,6 +31,7 @@ public class EventEmitterSQSIntegrationTest {
         org.junit.Assume.assumeTrue(ACCESS_KEY_ID != null && ACCESS_SECRET_KEY != null);
 
         injector = EventEmitterSQSTestHelper.createTestConfiguration(
+                Stage.PRODUCTION,
                 CONFIGURATION_ENABLED,
                 ACCESS_KEY_ID,
                 ACCESS_SECRET_KEY,

--- a/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventEmitterModule.java
@@ -5,6 +5,7 @@ import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.AmazonSQSException;
 import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
@@ -73,54 +74,4 @@ public class EventEmitterModule extends AbstractModule {
             final Encrypter encrypter) {
         return new EventEmitter(objectMapper, new EventHasher(new Sha256Util()), encrypter, eventSender);
     }
-
-    @Provides
-    @Singleton
-    private EventEmitterSQS getEventEmitter(
-            final SqsClient sqsClient) {
-        return new EventEmitterSQS(sqsClient);
-    }
-
-    @Provides
-    @Singleton
-    private SqsClient getAmazonSqsClient(
-            @Nullable final AmazonSQS amazonSqs,
-            final @Named("SourceQueueUrl") String sourceQueueUrl,
-            final Configuration configuration,
-            final ObjectMapper objectMapper) {
-        if (configuration.isEnabled()) {
-            return new AmazonSqsClient(amazonSqs, sourceQueueUrl, objectMapper);
-        }
-        return new StubSqsClient();
-    }
-
-    @Provides
-    @Singleton
-    @Nullable
-    private AmazonSQS getAmazonSqs(
-            final Configuration configuration,
-            @Nullable final AWSCredentials credentials) {
-        if (configuration.isEnabled()) {
-            return AmazonSQSClientBuilder.standard()
-                    .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                    .withRegion(configuration.getRegion())
-                    .build();
-        }
-        return null;
-    }
-
-    @Provides
-    @Singleton
-    @Nullable
-    @Named("SourceQueueUrl")
-    private String getQueueUrl(
-            @Nullable final AmazonSQS amazonSqs,
-            final Configuration configuration) {
-        if (configuration.isEnabled()) {
-            GetQueueUrlRequest queueUrlRequest = new GetQueueUrlRequest(configuration.getSourceQueueName());
-            return amazonSqs.getQueueUrl(queueUrlRequest).getQueueUrl();
-        }
-        return "";
-    }
-
 }

--- a/src/main/java/uk/gov/ida/eventemitter/sqs/EventEmitterSQSModule.java
+++ b/src/main/java/uk/gov/ida/eventemitter/sqs/EventEmitterSQSModule.java
@@ -1,0 +1,82 @@
+package uk.gov.ida.eventemitter.sqs;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.sqs.AmazonSQS;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
+import com.amazonaws.services.sqs.model.GetQueueUrlRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.AbstractModule;
+import com.google.inject.Provides;
+import uk.gov.ida.eventemitter.Configuration;
+
+import javax.annotation.Nullable;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+public class EventEmitterSQSModule extends AbstractModule {
+
+    @Override
+    protected void configure() {}
+
+    @Provides
+    @Singleton
+    @Nullable
+    private AWSCredentials getAmazonCredential(final Configuration configuration) {
+        if (configuration.isEnabled()) {
+            return new BasicAWSCredentials(configuration.getAccessKeyId(), configuration.getSecretAccessKey());
+        }
+        return null;
+    }
+
+    @Provides
+    @Singleton
+    private EventEmitterSQS getEventEmitter(
+            final SqsClient sqsClient) {
+        return new EventEmitterSQS(sqsClient);
+    }
+
+    @Provides
+    @Singleton
+    private SqsClient getAmazonSqsClient(
+            @Nullable final AmazonSQS amazonSqs,
+            final @Named("SourceQueueUrl") String sourceQueueUrl,
+            final Configuration configuration,
+            final ObjectMapper objectMapper) {
+        if (configuration.isEnabled()) {
+            return new AmazonSqsClient(amazonSqs, sourceQueueUrl, objectMapper);
+        }
+        return new StubSqsClient();
+    }
+
+    @Provides
+    @Singleton
+    @Nullable
+    private AmazonSQS getAmazonSqs(
+            final Configuration configuration,
+            @Nullable final AWSCredentials credentials) {
+        if (configuration.isEnabled()) {
+            return AmazonSQSClientBuilder.standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                    .withRegion(configuration.getRegion())
+                    .build();
+        }
+        return null;
+    }
+
+    @Provides
+    @Singleton
+    @Nullable
+    @Named("SourceQueueUrl")
+    private String getQueueUrl(
+            @Nullable final AmazonSQS amazonSqs,
+            final Configuration configuration) {
+        if (configuration.isEnabled()) {
+            GetQueueUrlRequest queueUrlRequest = new GetQueueUrlRequest(configuration.getSourceQueueName());
+            return amazonSqs.getQueueUrl(queueUrlRequest).getQueueUrl();
+        }
+        return "";
+    }
+
+}

--- a/src/test/java/uk/gov/ida/eventemitter/sqs/EventEmitterSQSModuleTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/sqs/EventEmitterSQSModuleTest.java
@@ -1,0 +1,89 @@
+package uk.gov.ida.eventemitter.sqs;
+
+import com.amazonaws.regions.Regions;
+import com.google.inject.ConfigurationException;
+import com.google.inject.CreationException;
+import com.google.inject.Injector;
+import com.google.inject.ProvisionException;
+import com.google.inject.Stage;
+import org.junit.Test;
+import uk.gov.ida.eventemitter.EventEmitterTestHelper;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+public class EventEmitterSQSModuleTest {
+
+    @Test
+    public void shouldThrowProvisionExceptionWhenQueueNameInvalid() {
+
+        final EventEmitterSQS eventEmitterSQS;
+
+        final Injector injector = EventEmitterSQSTestHelper.createTestConfiguration(
+                Stage.DEVELOPMENT,
+                true,
+                "key",
+                "secretkey",
+                Regions.EU_WEST_2,
+                null,
+                null,
+                ""
+        );
+
+        assertThatExceptionOfType(ProvisionException.class).isThrownBy(() -> {
+            injector.getInstance(EventEmitterSQS.class);
+        }).withMessageContaining("The security token included in the request is invalid");
+    }
+
+    @Test
+    public void shouldNotThrowExceptionWhenDisabled() {
+
+        final EventEmitterSQS eventEmitterSQS;
+
+        final Injector injector = EventEmitterSQSTestHelper.createTestConfiguration(
+                Stage.DEVELOPMENT,
+                false,
+                "key",
+                "secretkey",
+                Regions.EU_WEST_2,
+                null,
+                null,
+                ""
+        );
+
+        assertThatCode(() -> {
+            injector.getInstance(EventEmitterSQS.class);
+        }).doesNotThrowAnyException();
+
+    }
+
+    @Test
+    public void shouldThrowCreationExceptionWhenQueueNameInvalidProduction() {
+
+        assertThatExceptionOfType(CreationException.class).isThrownBy(() -> {
+            final Injector injector = EventEmitterSQSTestHelper.createTestConfiguration(
+                    Stage.PRODUCTION,
+                    true,
+                    "key",
+                    "secretkey",
+                    Regions.EU_WEST_2,
+                    null,
+                    null,
+                    ""
+            );
+        }).withMessageContaining("The security token included in the request is invalid");
+    }
+
+    @Test
+    public void shouldNotCreateEventEmitterSQSWhenUsingEventEmitterModule() {
+        final Injector injector = EventEmitterTestHelper.createTestConfiguration(
+                true,
+                "key",
+                "secretkey",
+                Regions.EU_WEST_2,
+                null);
+        assertThatExceptionOfType(ConfigurationException.class).isThrownBy(() -> {
+            injector.getInstance(EventEmitterSQS.class);
+        }).withMessageContaining("No implementation for uk.gov.ida.eventemitter.sqs.SqsClient was bound");
+    }
+}

--- a/src/test/java/uk/gov/ida/eventemitter/sqs/EventEmitterSQSTestHelper.java
+++ b/src/test/java/uk/gov/ida/eventemitter/sqs/EventEmitterSQSTestHelper.java
@@ -6,6 +6,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
+import com.google.inject.Stage;
 import com.google.inject.util.Modules;
 import uk.gov.ida.eventemitter.Configuration;
 import uk.gov.ida.eventemitter.EventEmitterModule;
@@ -22,6 +23,7 @@ public class EventEmitterSQSTestHelper {
     protected static final String SOURCE_QUEUE_NAME = "default-doc-checking-event-recorder-queue";
 
     public static Injector createTestConfiguration(
+            Stage stage,
             Boolean isEnabled,
             String accessKey,
             String secretAccessKey,
@@ -30,7 +32,7 @@ public class EventEmitterSQSTestHelper {
             String sourceQueueName,
             String queueAccountId
     ) {
-        return Guice.createInjector(new AbstractModule() {
+        return Guice.createInjector(stage, new AbstractModule() {
             @Override
             protected void configure() {
             }
@@ -48,6 +50,6 @@ public class EventEmitterSQSTestHelper {
                         sourceQueueName
                 );
             }
-        }, Modules.override(new EventEmitterModule()).with(new TestEventEmitterModule()));
+        }, Modules.override(new EventEmitterSQSModule()).with(new TestEventEmitterModule()));
     }
 }


### PR DESCRIPTION
- Including SQS Providers in the EventEmitterModule caused issues in Staging as Guice tries to instantiate everything in the module, even if it is not used in code.
- Moved all SQS related Providers to a separate module which will not be added to Guice if not needed.
- Additional tests added to capture circumstances of failure in Staging.

Co-authored-by: Alex Wilson <alex.wilson@digital.cabinet-office.gov.uk>