### PR TITLE
BAU - Use java11 docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
-FROM govukverify/java8:latest
+FROM openjdk:11-jdk
 
 RUN apt-get update \
-    && apt-get install -y python-pip build-essential maven sudo \
+    && apt-get install -y python-pip build-essential maven sudo unzip jq curl wget git make\
     && curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - \
     && apt-get install -y nodejs \
-    && pip install virtualenv
+    && pip install virtualenv \
+    && apt-get clean
+
 
 WORKDIR /home/user
 RUN groupadd -g 116 team;\

--- a/PublicDockerfile
+++ b/PublicDockerfile
@@ -1,12 +1,13 @@
-FROM govukverify/java8:latest
+FROM openjdk:11-jdk
 
 ENV VERIFY_USE_PUBLIC_BINARIES=true
 
 RUN apt-get update \
-    && apt-get install -y python-pip build-essential maven sudo \
+    && apt-get install -y python-pip build-essential maven sudo unzip jq curl wget git make\
     && curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash - \
     && apt-get install -y nodejs \
-    && pip install virtualenv
+    && pip install virtualenv \
+    && apt-get clean
 
 WORKDIR /home/user
 RUN groupadd -g 116 team;\

--- a/src/intTest/java/uk/gov/ida/eventemitter/sqs/AmazonSqsClientIntegrationTest.java
+++ b/src/intTest/java/uk/gov/ida/eventemitter/sqs/AmazonSqsClientIntegrationTest.java
@@ -2,8 +2,6 @@ package uk.gov.ida.eventemitter.sqs;
 
 import cloud.localstack.LocalstackTestRunner;
 import cloud.localstack.TestUtils;
-import cloud.localstack.docker.LocalstackDockerTestRunner;
-import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.AmazonSQSException;
 import com.amazonaws.services.sqs.model.Message;


### PR DESCRIPTION
- Stop using the Verify custom java8 docker image and use the openjdk 11 image instead.