### PR TITLE
Add preferred and maximum level of assurance event detail keys

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/EventDetailsKey.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventDetailsKey.java
@@ -12,7 +12,9 @@ public enum EventDetailsKey {
     hub_event_type,
     pid,
     minimum_level_of_assurance,
-    required_level_of_assurance,
+    maximum_level_of_assurance,
+    required_level_of_assurance, // deprecated
+    preferred_level_of_assurance,
     provided_level_of_assurance,
     downstream_uri,
     message_id,


### PR DESCRIPTION
This PR is 1 part of several across Verify to be able to support billing for new special case `LOA2,LOA1/exact` requests. It adds two new details keys for events to support the information that will be emitted by the hub, and eventually recorded in the billing and audit tables.

The full set of changes being made is laid out in:

* [ADR 36 billing changes plan](https://docs.google.com/document/d/1hblVU0wquj6Z3-b9V75z6jb1wt3Nnpjh2MNHxNGgTBE/edit?usp=sharing)

For context, please see:

* [ADR 35](https://github.com/alphagov/verify-architecture/blob/master/adr/0035-allow-specified-loa2-services-to-receive-loa1-identities.md) (sending LOA2,LOA1/exact requests to IDPs)
* [ADR 36](https://github.com/alphagov/verify-architecture/blob/master/adr/0036-support-billing-on-provided-loa.md) (changes to support billing for the new requests)