### PR TITLE
Remove required_level_of_assurance

### DIFF
--- a/src/main/java/uk/gov/ida/eventemitter/EventDetailsKey.java
+++ b/src/main/java/uk/gov/ida/eventemitter/EventDetailsKey.java
@@ -13,7 +13,6 @@ public enum EventDetailsKey {
     pid,
     minimum_level_of_assurance,
     maximum_level_of_assurance,
-    required_level_of_assurance, // deprecated
     preferred_level_of_assurance,
     provided_level_of_assurance,
     downstream_uri,


### PR DESCRIPTION
- We no use the required_level_of_assurance so we can remove it.

 Co-authored-by: Lewis Westbury <lewis.wetbury@digital.cabinet-office.gov.uk>