### PR TITLE
HUB-908: Pull from maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
                     sourceSets.test.output,
                     configurations.compile,
                     configurations.testCompile,
-                    'cloud.localstack:localstack-utils:0.2.1'
+                    'cloud.localstack:localstack-utils:0.2.11'
 }
 
 task integrationTest(type: Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 def buildVersion = "2.0.0-${System.env.BUILD_NUMBER ?: 'SNAPSHOT'}"
 group = "uk.gov.ida"
@@ -17,8 +16,7 @@ archivesBaseName = "verify-event-emitter"
 repositories {
     if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
         logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-        maven { url 'https://dl.bintray.com/alphagov/maven-test' }
-        jcenter()
+        mavenCentral()
     }
     else {
         maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }
@@ -44,11 +42,11 @@ dependencies {
                 'com.google.code.findbugs:jsr305:1.3.9',
                 'com.amazonaws:aws-java-sdk-sqs:1.11.562',
                 'com.fasterxml.jackson.datatype:jackson-datatype-joda:2.8.10',
-                'uk.gov.ida:dropwizard-logstash:1.3.12-72',
+                'uk.gov.ida:dropwizard-logstash:1.3.22-89',
                 'org.slf4j:slf4j-api:1.7.26'
 
     testCompile 'junit:junit:4.12',
-                'uk.gov.ida:common-test-utils:2.0.0-44',
+                'uk.gov.ida:common-test-utils:2.0.0-65',
                 'org.assertj:assertj-core:3.12.2',
                 'org.mockito:mockito-core:2.27.0',
                 'nl.jqno.equalsverifier:equalsverifier:2.4.7',

--- a/src/intTest/java/uk/gov/ida/eventemitter/sqs/AmazonSqsClientIntegrationTest.java
+++ b/src/intTest/java/uk/gov/ida/eventemitter/sqs/AmazonSqsClientIntegrationTest.java
@@ -1,7 +1,8 @@
 package uk.gov.ida.eventemitter.sqs;
 
 import cloud.localstack.LocalstackTestRunner;
-import cloud.localstack.TestUtils;
+import cloud.localstack.awssdkv1.TestUtils;
+import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.AmazonSQSException;
 import com.amazonaws.services.sqs.model.Message;
@@ -18,6 +19,7 @@ import uk.gov.ida.eventemitter.AuditEvent;
 import uk.gov.ida.eventemitter.utils.TestEventBuilder;
 
 @RunWith(LocalstackTestRunner.class)
+@LocalstackDockerProperties(services = { "sqs" })
 public class AmazonSqsClientIntegrationTest {
 
     @Rule
@@ -60,11 +62,11 @@ public class AmazonSqsClientIntegrationTest {
     @Test
     public void shouldThrowErrorWhenSendingMessageToSqsWhereQueueDoesNotExist() {
         expectedException.expect(AmazonSQSException.class);
-        expectedException.expectMessage("AWS.SimpleQueueService.NonExistentQueue; see the SQS docs. " +
+        expectedException.expectMessage("The specified queue does not exist for this wsdl version. " +
                 "(Service: AmazonSQS; " +
-                "Status Code: 400; " +
+                "Status Code: 404; " +
                 "Error Code: AWS.SimpleQueueService.NonExistentQueue; " +
-                "Request ID: 00000000-0000-0000-0000-000000000000)");
+                "Request ID: ");
 
         sqsClient = new AmazonSqsClient(sqs, queueUrl + "notHere", objectMapper);
 


### PR DESCRIPTION
### HUB-908: Pull from maven central
Bintray and jcenter are going away. This updates the public builds to
pull from maven central. It also bumps versions of our libs to ensure
they're being pulled from maven central.

Also removes the redundant `apply` for the nexus publishing plugin. The
plugin block applies if for us.

### HUB-908: Fix integration tests

The version of localstack we were using was a little out of date and not
working. This bumps to the latest versions and configures it correctly.

The error message in the second integration test now returns a random
request ID, so the expected string has been shortened. The test
frameworks checks that the expected string is a substring of the actual
message, so this still works and checks what we actually care about.