### PR TITLE
BAU - Fix unit tests and add github actions

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -1,0 +1,37 @@
+name: Pre-merge checks
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+
+jobs:
+    build:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out repository code
+          uses: actions/checkout@v2
+        - name: Set up JDK 8
+          uses: actions/setup-java@v2
+          with:
+            java-version: '8'
+            distribution: 'adopt'
+        - name: Run Build
+          run: ./gradlew --parallel build -x test
+
+    run-unit-tests:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out repository code
+          uses: actions/checkout@v2
+        - name: Set up JDK 8
+          uses: actions/setup-java@v2
+          with:
+            java-version: '8'
+            distribution: 'adopt'
+        - name: Run Unit Tests
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          run: ./gradlew --parallel test

--- a/src/main/java/uk/gov/ida/eventemitter/sqs/AmazonSqsClient.java
+++ b/src/main/java/uk/gov/ida/eventemitter/sqs/AmazonSqsClient.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.sqs.AmazonSQS;
 import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,7 @@ public class AmazonSqsClient implements SqsClient {
                            final ObjectMapper objectMapper) {
         this.sqs = sqs;
         this.queueUrl = queueUrl;
-        this.objectMapper = objectMapper;
+        this.objectMapper = objectMapper.registerModule(new JodaModule());
     }
 
     @Override

--- a/src/test/java/uk/gov/ida/eventemitter/sqs/AmazonSqsClientTest.java
+++ b/src/test/java/uk/gov/ida/eventemitter/sqs/AmazonSqsClientTest.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.sqs.model.SendMessageRequest;
 import com.amazonaws.services.sqs.model.SendMessageResult;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -31,7 +32,7 @@ public class AmazonSqsClientTest {
     @Before
     public void setUp() {
         sqsClient = new AmazonSqsClient(sqs, QUEUE_URL, new ObjectMapper());
-        objectMapper = new ObjectMapper();
+        objectMapper = new ObjectMapper().registerModule(new JodaModule());
     }
 
     @Test


### PR DESCRIPTION
- We need to register the JodaModule on the ObjectMapper due to the upgrade of dropwizard-logstash which uplifted jackson. This is because Joda datatypes are no longer supported by default.
- Add github actions to catch failures before merging